### PR TITLE
HW Architecture in SWID tags and softwareIDs

### DIFF
--- a/swid_generator/environments/common.py
+++ b/swid_generator/environments/common.py
@@ -5,7 +5,7 @@ class CommonEnvironment(object):
     @staticmethod
     def get_architecture():
         #returns '64bit' or '32bit'
-        return platform.architecture()[0]
+        return platform.machine()
 
     @staticmethod
     def get_os_string(self):

--- a/tests/test_SwidGenerator.py
+++ b/tests/test_SwidGenerator.py
@@ -38,7 +38,7 @@ class TestEnvironment(CommonEnvironment):
 
     @staticmethod
     def architecture():
-        return platform.architecture()[0]
+        return platform.machine()
 
 
 @pytest.fixture


### PR DESCRIPTION
The uniqueID in a SWID tag generated by the swidGenerator has currrently the form

uniqueId="Ubuntu_13.10-64bit-zlib1g-dev-1:1.2.8.dfsg-1ubuntu1"

Instead of "64bit" or "32bit" for designating the hardware architecture I would prefer the output of the system command

  uname --machine

instead which returns e.g. "x86_64" for 64-bit systems and "i686" on 32-bit Intel platforms. This would be consistent with the naming scheme the strongSwan OS IMC uses.

BTW - the swidGenerator in the software-id mode generates IDs of the form

regid.2004-03.org.strongswan_Ubuntu_13.10-zlib1g-dev-1:1.2.8.dfsg-1ubuntu1

which does not include the HW architecture.

Regards

Andreas
