### PR TITLE
Fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,8 @@ Generate SWID tags:
                             whitespace characters. Default is
                             "regid.2004-03.org.strongswan".
       --entity-name ENTITY_NAME
-                            The entity name used in the <Entity> XML tag. May not contain
-                            any whitespace characters. Default is "strongSwan".
+                            The entity name used in the <Entity> XML tag. Default is
+                            "strongSwan Project".
       --full                Dump the full SWID tags including file tags for each package.
       --pretty              Indent the XML output.
 

--- a/swid_generator/argparser.py
+++ b/swid_generator/argparser.py
@@ -68,7 +68,6 @@ class MainArgumentParser(object):
         swid_parser.add_argument('--entity-name', dest='entity_name', type=entity_name_string,
                                  default=entity_name_string(settings.DEFAULT_ENTITY_NAME),
                                  help='The entity name used in the <Entity> XML tag. '
-                                      'May not contain any whitespace characters. '
                                       'Default is "%s".' % settings.DEFAULT_ENTITY_NAME)
         swid_parser.add_argument('--full', action='store_true', default=False,
                                  help='Dump the full SWID tags including file tags for each package.')

--- a/swid_generator/settings.py
+++ b/swid_generator/settings.py
@@ -1,2 +1,2 @@
 DEFAULT_REGID = u'regid.2004-03.org.strongswan'
-DEFAULT_ENTITY_NAME = u'strongSwan'
+DEFAULT_ENTITY_NAME = u'strongSwan Project'

--- a/tests/dumps/rpm-networkmanager-normal-template.xml
+++ b/tests/dumps/rpm-networkmanager-normal-template.xml
@@ -2,5 +2,5 @@
 <SoftwareIdentity name="NetworkManager" uniqueId="fedora_19-i686-NetworkManager-0.9.8.2-2.fc19"
                   version="0.9.8.2-2.fc19" versionScheme="alphanumeric"
                   xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-    <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+    <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>

--- a/tests/dumps/swid_tags/dpkg-swid-full.txt
+++ b/tests/dumps/swid_tags/dpkg-swid-full.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="accountsservice" uniqueId="Ubuntu_12.04-i686-accountsservice-0.6.15-2ubuntu9" version="0.6.15-2ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/accountsservice" name="accounts-daemon"/>
     <File location="/usr/share/dbus-1/interfaces" name="org.freedesktop.Accounts.xml"/>
@@ -26,7 +26,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="adduser" uniqueId="Ubuntu_12.04-i686-adduser-3.113ubuntu2" version="3.113ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="deluser.conf"/>
     <File location="/usr/sbin" name="adduser"/>
@@ -98,7 +98,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="apparmor" uniqueId="Ubuntu_12.04-i686-apparmor-2.7.102-0ubuntu3" version="2.7.102-0ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/apparmor.d/local" name="README"/>
     <File location="/etc/apparmor.d/tunables" name="alias"/>
@@ -200,7 +200,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="apt" uniqueId="Ubuntu_12.04-i686-apt-0.8.16~exp12ubuntu10" version="0.8.16~exp12ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/pl/man8" name="apt-cdrom.8.gz"/>
     <File location="/usr/share/man/pl/man8" name="apt-config.8.gz"/>
@@ -355,7 +355,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="apt-transport-https" uniqueId="Ubuntu_12.04-i686-apt-transport-https-0.8.16~exp12ubuntu10" version="0.8.16~exp12ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/apt-transport-https" name="apt-transport-https.README"/>
     <File location="/usr/share/doc/apt-transport-https" name="copyright"/>
@@ -367,7 +367,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="apt-utils" uniqueId="Ubuntu_12.04-i686-apt-utils-0.8.16~exp12ubuntu10" version="0.8.16~exp12ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/pl/man1" name="apt-sortpkgs.1.gz"/>
     <File location="/usr/share/man/pl/man1" name="apt-extracttemplates.1.gz"/>
@@ -404,7 +404,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="apt-xapian-index" uniqueId="Ubuntu_12.04-i686-apt-xapian-index-0.44ubuntu5" version="0.44ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="axi-cache"/>
     <File location="/usr/sbin" name="update-apt-xapian-index"/>
@@ -464,7 +464,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="aptitude" uniqueId="Ubuntu_12.04-i686-aptitude-0.6.6-1ubuntu1" version="0.6.6-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="aptitude-create-state-bundle"/>
     <File location="/usr/bin" name="aptitude-curses"/>
@@ -580,7 +580,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="at" uniqueId="Ubuntu_12.04-i686-at-3.1.13-1ubuntu1" version="3.1.13-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="batch"/>
     <File location="/usr/bin" name="at"/>
@@ -608,7 +608,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="base-files" uniqueId="Ubuntu_12.04-i686-base-files-6.5ubuntu6" version="6.5ubuntu6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/base-files" name="README"/>
     <File location="/usr/share/doc/base-files" name="README.FHS"/>
@@ -653,7 +653,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="base-passwd" uniqueId="Ubuntu_12.04-i686-base-passwd-3.5.24" version="3.5.24" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc-base" name="users-and-groups"/>
     <File location="/usr/share/base-passwd" name="passwd.master"/>
@@ -676,7 +676,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bash" uniqueId="Ubuntu_12.04-i686-bash-4.2-2ubuntu2" version="4.2-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="bash"/>
     <File location="/etc/skel" name=".bashrc"/>
@@ -709,7 +709,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bash-completion" uniqueId="Ubuntu_12.04-i686-bash-completion-1:1.3-1ubuntu8" version="1:1.3-1ubuntu8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/bash_completion.d/helpers" name="perl"/>
     <File location="/etc/bash_completion.d" name="abook"/>
@@ -906,7 +906,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bind9-host" uniqueId="Ubuntu_12.04-i686-bind9-host-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="host"/>
     <File location="/usr/share/doc/bind9-host" name="copyright"/>
@@ -917,7 +917,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="binutils" uniqueId="Ubuntu_12.04-i686-binutils-2.22-6ubuntu1" version="2.22-6ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man1" name="ar.1.gz"/>
     <File location="/usr/share/man/man1" name="as.1.gz"/>
@@ -1052,7 +1052,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bsdmainutils" uniqueId="Ubuntu_12.04-i686-bsdmainutils-8.2.3ubuntu1" version="8.2.3ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/calendar" name="default"/>
     <File location="/etc/cron.daily" name="bsdmainutils"/>
@@ -1157,7 +1157,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bsdutils" uniqueId="Ubuntu_12.04-i686-bsdutils-1:2.20.1-1ubuntu3" version="1:2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="renice"/>
     <File location="/usr/bin" name="scriptreplay"/>
@@ -1178,7 +1178,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="busybox-initramfs" uniqueId="Ubuntu_12.04-i686-busybox-initramfs-1:1.18.5-1ubuntu4" version="1:1.18.5-1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/busybox-initramfs" name="copyright"/>
     <File location="/usr/share/doc/busybox-initramfs" name="changelog.Debian.gz"/>
@@ -1188,7 +1188,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="busybox-static" uniqueId="Ubuntu_12.04-i686-busybox-static-1:1.18.5-1ubuntu4" version="1:1.18.5-1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="busybox"/>
     <File location="/usr/share/doc/busybox-static" name="copyright"/>
@@ -1200,7 +1200,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bzip2" uniqueId="Ubuntu_12.04-i686-bzip2-1.0.6-1" version="1.0.6-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="bzip2"/>
     <File location="/bin" name="bunzip2"/>
@@ -1233,7 +1233,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ca-certificates" uniqueId="Ubuntu_12.04-i686-ca-certificates-20111211" version="20111211" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/ca-certificates/cacert.org" name="cacert.org.crt"/>
     <File location="/usr/share/ca-certificates/debconf.org" name="ca.crt"/>
@@ -1398,7 +1398,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="command-not-found" uniqueId="Ubuntu_12.04-i686-command-not-found-0.2.46ubuntu6" version="0.2.46ubuntu6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/command-not-found" name="README"/>
     <File location="/usr/share/doc/command-not-found" name="copyright"/>
@@ -1418,7 +1418,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="command-not-found-data" uniqueId="Ubuntu_12.04-i686-command-not-found-data-0.2.46ubuntu6" version="0.2.46ubuntu6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/command-not-found/programs.d" name="all-main.db"/>
     <File location="/usr/share/command-not-found/programs.d" name="all-multiverse.db"/>
@@ -1435,7 +1435,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="console-setup" uniqueId="Ubuntu_12.04-i686-console-setup-1.70ubuntu5" version="1.70ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/consolefonts" name="Arabic-Fixed15.psf.gz"/>
     <File location="/usr/share/consolefonts" name="Arabic-Fixed16.psf.gz"/>
@@ -1817,7 +1817,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="coreutils" uniqueId="Ubuntu_12.04-i686-coreutils-8.13-3ubuntu3" version="8.13-3ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="cat"/>
     <File location="/bin" name="chgrp"/>
@@ -2038,7 +2038,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cpio" uniqueId="Ubuntu_12.04-i686-cpio-2.11-7ubuntu3" version="2.11-7ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/cpio" name="copyright"/>
     <File location="/usr/share/doc/cpio" name="NEWS.gz"/>
@@ -2054,7 +2054,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cpp" uniqueId="Ubuntu_12.04-i686-cpp-4:4.6.3-1ubuntu5" version="4:4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man7" name="gpl.7gcc.gz"/>
     <File location="/usr/share/man/man7" name="gfdl.7gcc.gz"/>
@@ -2071,7 +2071,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cpp-4.6" uniqueId="Ubuntu_12.04-i686-cpp-4.6-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="cpp-4.6"/>
     <File location="/usr/share/man/man1" name="cpp-4.6.1.gz"/>
@@ -2086,7 +2086,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="crda" uniqueId="Ubuntu_12.04-i686-crda-1.1.2-1ubuntu1" version="1.1.2-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/crda" name="copyright"/>
     <File location="/usr/share/doc/crda" name="changelog.Debian.gz"/>
@@ -2105,7 +2105,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cron" uniqueId="Ubuntu_12.04-i686-cron-3.0pl1-120ubuntu3" version="3.0pl1-120ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="crontab"/>
     <File location="/usr/sbin" name="cron"/>
@@ -2142,7 +2142,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dash" uniqueId="Ubuntu_12.04-i686-dash-0.5.7-2ubuntu2" version="0.5.7-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="dash"/>
     <File location="/usr/share/menu" name="dash"/>
@@ -2159,7 +2159,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dbus" uniqueId="Ubuntu_12.04-i686-dbus-1.4.18-1ubuntu1" version="1.4.18-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dbus-1" name="session.conf"/>
     <File location="/etc/dbus-1" name="system.conf"/>
@@ -2192,7 +2192,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="debconf" uniqueId="Ubuntu_12.04-i686-debconf-1.5.42ubuntu1" version="1.5.42ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/apt/apt.conf.d" name="70debconf"/>
     <File location="/etc/bash_completion.d" name="debconf"/>
@@ -2348,7 +2348,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="debconf-i18n" uniqueId="Ubuntu_12.04-i686-debconf-i18n-1.5.42ubuntu1" version="1.5.42ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/locale/ar/LC_MESSAGES" name="debconf.mo"/>
     <File location="/usr/share/locale/ast/LC_MESSAGES" name="debconf.mo"/>
@@ -2448,7 +2448,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="debianutils" uniqueId="Ubuntu_12.04-i686-debianutils-4.2.1ubuntu2" version="4.2.1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="run-parts"/>
     <File location="/bin" name="which"/>
@@ -2504,7 +2504,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="diffutils" uniqueId="Ubuntu_12.04-i686-diffutils-1:3.2-1ubuntu1" version="1:3.2-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="diff3"/>
     <File location="/usr/bin" name="sdiff"/>
@@ -2523,7 +2523,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dmidecode" uniqueId="Ubuntu_12.04-i686-dmidecode-2.11-4" version="2.11-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="dmidecode"/>
     <File location="/usr/sbin" name="biosdecode"/>
@@ -2541,7 +2541,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dmsetup" uniqueId="Ubuntu_12.04-i686-dmsetup-2:1.02.48-4ubuntu7" version="2:1.02.48-4ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/udev/rules.d" name="55-dm.rules"/>
     <File location="/lib/udev/rules.d" name="60-persistent-storage-dm.rules"/>
@@ -2557,7 +2557,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dnsutils" uniqueId="Ubuntu_12.04-i686-dnsutils-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="dig"/>
     <File location="/usr/bin" name="nslookup"/>
@@ -2572,7 +2572,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dosfstools" uniqueId="Ubuntu_12.04-i686-dosfstools-3.0.12-1ubuntu1" version="3.0.12-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="dosfsck"/>
     <File location="/sbin" name="dosfslabel"/>
@@ -2600,7 +2600,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dpkg" uniqueId="Ubuntu_12.04-i686-dpkg-1.16.1.2ubuntu7" version="1.16.1.2ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dpkg" name="dpkg.cfg"/>
     <File location="/etc/alternatives" name="README"/>
@@ -2738,7 +2738,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="e2fslibs" uniqueId="Ubuntu_12.04-i686-e2fslibs-1.42-1ubuntu2" version="1.42-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libext2fs.so.2.4"/>
     <File location="/lib/i386-linux-gnu" name="libe2p.so.2.3"/>
@@ -2751,7 +2751,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="e2fsprogs" uniqueId="Ubuntu_12.04-i686-e2fsprogs-1.42-1ubuntu2" version="1.42-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="e2fsck"/>
     <File location="/sbin" name="debugfs"/>
@@ -2828,7 +2828,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ed" uniqueId="Ubuntu_12.04-i686-ed-1.5-3" version="1.5-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="ed"/>
     <File location="/usr/share/info" name="ed.info.gz"/>
@@ -2846,7 +2846,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="eject" uniqueId="Ubuntu_12.04-i686-eject-2.1.5+deb1+cvs20081104-9" version="2.1.5+deb1+cvs20081104-9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="volname"/>
     <File location="/usr/bin" name="eject"/>
@@ -2865,7 +2865,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="file" uniqueId="Ubuntu_12.04-i686-file-5.09-2" version="5.09-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="file"/>
     <File location="/usr/share/bug/file" name="control"/>
@@ -2880,7 +2880,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="findutils" uniqueId="Ubuntu_12.04-i686-findutils-4.4.2-4ubuntu1" version="4.4.2-4ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/findutils" name="NEWS.Debian.gz"/>
     <File location="/usr/share/doc/findutils" name="NEWS.gz"/>
@@ -2901,7 +2901,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="friendly-recovery" uniqueId="Ubuntu_12.04-i686-friendly-recovery-0.2.25" version="0.2.25" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/recovery-mode" name="recovery-menu"/>
     <File location="/lib/recovery-mode" name="l10n.sh"/>
@@ -2925,7 +2925,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ftp" uniqueId="Ubuntu_12.04-i686-ftp-0.17-25" version="0.17-25" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="netkit-ftp"/>
     <File location="/usr/share/man/man1" name="netkit-ftp.1.gz"/>
@@ -2941,7 +2941,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="fuse" uniqueId="Ubuntu_12.04-i686-fuse-2.8.6-2ubuntu2" version="2.8.6-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="fusermount"/>
     <File location="/bin" name="ulockmgr_server"/>
@@ -2962,7 +2962,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gcc" uniqueId="Ubuntu_12.04-i686-gcc-4:4.6.3-1ubuntu5" version="4:4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="c89-gcc"/>
     <File location="/usr/bin" name="c99-gcc"/>
@@ -2980,7 +2980,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gcc-4.6" uniqueId="Ubuntu_12.04-i686-gcc-4.6-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="gcov-4.6"/>
     <File location="/usr/bin" name="gcc-4.6"/>
@@ -3067,7 +3067,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gcc-4.6-base" uniqueId="Ubuntu_12.04-i686-gcc-4.6-base-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/gcc-4.6-base" name="copyright"/>
     <File location="/usr/share/doc/gcc-4.6-base" name="README.Debian.i386.gz"/>
@@ -3079,7 +3079,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="geoip-database" uniqueId="Ubuntu_12.04-i686-geoip-database-20111220-1" version="20111220-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/geoip-database" name="copyright"/>
     <File location="/usr/share/doc/geoip-database" name="changelog.Debian.gz"/>
@@ -3090,7 +3090,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gettext-base" uniqueId="Ubuntu_12.04-i686-gettext-base-0.18.1.1-5ubuntu3" version="0.18.1.1-5ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/gettext-base" name="ABOUT-NLS"/>
     <File location="/usr/share/doc/gettext-base" name="copyright"/>
@@ -3120,7 +3120,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gir1.2-glib-2.0" uniqueId="Ubuntu_12.04-i686-gir1.2-glib-2.0-1.32.0-1" version="1.32.0-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/gir1.2-glib-2.0" name="copyright"/>
     <File location="/usr/lib/girepository-1.0" name="Gio-2.0.typelib"/>
@@ -3138,7 +3138,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="git" uniqueId="Ubuntu_12.04-i686-git-1:1.7.9.5-1" version="1:1.7.9.5-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="git"/>
     <File location="/usr/bin" name="git-upload-pack"/>
@@ -3583,7 +3583,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="git-man" uniqueId="Ubuntu_12.04-i686-git-man-1:1.7.9.5-1" version="1:1.7.9.5-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man3" name="Git.3pm.gz"/>
     <File location="/usr/share/man/man1" name="git-am.1.gz"/>
@@ -3750,7 +3750,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gnupg" uniqueId="Ubuntu_12.04-i686-gnupg-1.4.11-3ubuntu2" version="1.4.11-3ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="gpg"/>
     <File location="/usr/bin" name="gpg-zip"/>
@@ -3790,7 +3790,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gpgv" uniqueId="Ubuntu_12.04-i686-gpgv-1.4.11-3ubuntu2" version="1.4.11-3ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="gpgv"/>
     <File location="/usr/share/doc/gpgv" name="copyright"/>
@@ -3801,7 +3801,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grep" uniqueId="Ubuntu_12.04-i686-grep-2.10-1" version="2.10-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="rgrep"/>
     <File location="/usr/share/info" name="grep.info.gz"/>
@@ -3824,7 +3824,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="groff-base" uniqueId="Ubuntu_12.04-i686-groff-base-1.21-7" version="1.21-7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="preconv"/>
     <File location="/usr/bin" name="eqn"/>
@@ -3996,7 +3996,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grub-common" uniqueId="Ubuntu_12.04-i686-grub-common-1.99-21ubuntu3.1" version="1.99-21ubuntu3.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="grub-kbdcomp"/>
     <File location="/usr/bin" name="grub-mkrelpath"/>
@@ -4065,7 +4065,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grub-gfxpayload-lists" uniqueId="Ubuntu_12.04-i686-grub-gfxpayload-lists-0.6" version="0.6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="update-grub-gfxpayload"/>
     <File location="/usr/share/grub-gfxpayload-lists/blacklist" name="00_header"/>
@@ -4079,7 +4079,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grub-pc" uniqueId="Ubuntu_12.04-i686-grub-pc-1.99-21ubuntu3.1" version="1.99-21ubuntu3.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="upgrade-from-grub-legacy"/>
     <File location="/usr/lib/grub-legacy" name="update-grub"/>
@@ -4099,7 +4099,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grub-pc-bin" uniqueId="Ubuntu_12.04-i686-grub-pc-bin-1.99-21ubuntu3.1" version="1.99-21ubuntu3.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/grub/i386-pc" name="moddep.lst"/>
     <File location="/usr/lib/grub/i386-pc" name="password.mod"/>
@@ -4319,7 +4319,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grub2-common" uniqueId="Ubuntu_12.04-i686-grub2-common-1.99-21ubuntu3.1" version="1.99-21ubuntu3.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="grub-reboot"/>
     <File location="/usr/sbin" name="update-grub"/>
@@ -4338,7 +4338,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gzip" uniqueId="Ubuntu_12.04-i686-gzip-1.4-1ubuntu2" version="1.4-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="gzip"/>
     <File location="/bin" name="gunzip"/>
@@ -4379,7 +4379,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hdparm" uniqueId="Ubuntu_12.04-i686-hdparm-9.37-0ubuntu3" version="9.37-0ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/udev/rules.d" name="85-hdparm.rules"/>
     <File location="/lib/udev" name="hdparm"/>
@@ -4406,7 +4406,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hostname" uniqueId="Ubuntu_12.04-i686-hostname-3.06ubuntu1" version="3.06ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="hostname"/>
     <File location="/bin" name="dnsdomainname"/>
@@ -4428,7 +4428,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ifupdown" uniqueId="Ubuntu_12.04-i686-ifupdown-0.7~beta2ubuntu8" version="0.7~beta2ubuntu8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/ifupdown/examples" name="bridge"/>
     <File location="/usr/share/doc/ifupdown/examples" name="check-mac-address.sh"/>
@@ -4464,7 +4464,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="info" uniqueId="Ubuntu_12.04-i686-info-4.13a.dfsg.1-8ubuntu2" version="4.13a.dfsg.1-8ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="info"/>
     <File location="/usr/bin" name="infokey"/>
@@ -4486,7 +4486,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="initramfs-tools" uniqueId="Ubuntu_12.04-i686-initramfs-tools-0.99ubuntu13" version="0.99ubuntu13" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/initramfs-tools" name="initramfs.conf"/>
     <File location="/etc/initramfs-tools" name="update-initramfs.conf"/>
@@ -4539,7 +4539,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="initramfs-tools-bin" uniqueId="Ubuntu_12.04-i686-initramfs-tools-bin-0.99ubuntu13" version="0.99ubuntu13" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/initramfs-tools/bin" name="wait-for-root"/>
     <File location="/usr/lib/initramfs-tools/bin" name="rzscontrol"/>
@@ -4551,7 +4551,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="initscripts" uniqueId="Ubuntu_12.04-i686-initscripts-2.88dsf-13.10ubuntu11" version="2.88dsf-13.10ubuntu11" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="mountpoint"/>
     <File location="/usr/share/initscripts" name="default.rcS"/>
@@ -4589,7 +4589,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="insserv" uniqueId="Ubuntu_12.04-i686-insserv-1.14.0-2.1ubuntu2" version="1.14.0-2.1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/bash_completion.d" name="insserv"/>
     <File location="/etc" name="insserv.conf"/>
@@ -4617,7 +4617,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="install-info" uniqueId="Ubuntu_12.04-i686-install-info-4.13a.dfsg.1-8ubuntu2" version="4.13a.dfsg.1-8ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="update-info-dir"/>
     <File location="/usr/share/man/man1" name="install-info.1.gz"/>
@@ -4638,7 +4638,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="installation-report" uniqueId="Ubuntu_12.04-i686-installation-report-2.46ubuntu1" version="2.46ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/installation-report" name="install-report.template"/>
     <File location="/usr/share/bug/installation-reports" name="script"/>
@@ -4655,7 +4655,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iproute" uniqueId="Ubuntu_12.04-i686-iproute-20111117-1ubuntu2" version="20111117-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="ss"/>
     <File location="/bin" name="ip"/>
@@ -4720,7 +4720,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iptables" uniqueId="Ubuntu_12.04-i686-iptables-1.4.12-1ubuntu4" version="1.4.12-1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="nfnl_osf"/>
     <File location="/sbin" name="xtables-multi"/>
@@ -4885,7 +4885,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iputils-ping" uniqueId="Ubuntu_12.04-i686-iputils-ping-3:20101006-1ubuntu1" version="3:20101006-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="ping"/>
     <File location="/bin" name="ping6"/>
@@ -4900,7 +4900,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iputils-tracepath" uniqueId="Ubuntu_12.04-i686-iputils-tracepath-3:20101006-1ubuntu1" version="3:20101006-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="traceroute6.iputils"/>
     <File location="/usr/bin" name="tracepath"/>
@@ -4916,7 +4916,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ipython" uniqueId="Ubuntu_12.04-i686-ipython-0.12.1+dfsg-0ubuntu1" version="0.12.1+dfsg-0ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="ipcluster"/>
     <File location="/usr/bin" name="ipcontroller"/>
@@ -5448,7 +5448,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="irqbalance" uniqueId="Ubuntu_12.04-i686-irqbalance-0.56-1ubuntu4" version="0.56-1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="irqbalance"/>
     <File location="/usr/share/doc/irqbalance" name="copyright"/>
@@ -5461,7 +5461,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="isc-dhcp-client" uniqueId="Ubuntu_12.04-i686-isc-dhcp-client-4.1.ESV-R4-0ubuntu5" version="4.1.ESV-R4-0ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dhcp/dhclient-enter-hooks.d" name="debug"/>
     <File location="/etc/dhcp/dhclient-exit-hooks.d" name="debug"/>
@@ -5488,7 +5488,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="isc-dhcp-common" uniqueId="Ubuntu_12.04-i686-isc-dhcp-common-4.1.ESV-R4-0ubuntu5" version="4.1.ESV-R4-0ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/ja/man8" name="dhclient.8.gz"/>
     <File location="/usr/share/man/ja/man8" name="dhclient-script.8.gz"/>
@@ -5512,7 +5512,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iso-codes" uniqueId="Ubuntu_12.04-i686-iso-codes-3.31-1" version="3.31-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/xml/iso-codes" name="iso_15924.xml"/>
     <File location="/usr/share/xml/iso-codes" name="iso_3166.xml"/>
@@ -5925,7 +5925,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kbd" uniqueId="Ubuntu_12.04-i686-kbd-1.15.2-3ubuntu4" version="1.15.2-3ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="openvt"/>
     <File location="/bin" name="fgconsole"/>
@@ -6034,7 +6034,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="keyboard-configuration" uniqueId="Ubuntu_12.04-i686-keyboard-configuration-1.70ubuntu5" version="1.70ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/console-setup" name="keyboard"/>
     <File location="/usr/share/doc/keyboard-configuration" name="README.Debian"/>
@@ -6054,7 +6054,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="klibc-utils" uniqueId="Ubuntu_12.04-i686-klibc-utils-1.5.25-1ubuntu2" version="1.5.25-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="klibc-utils"/>
     <File location="/usr/lib/klibc/bin" name="mkfifo"/>
@@ -6101,7 +6101,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="krb5-locales" uniqueId="Ubuntu_12.04-i686-krb5-locales-1.10+dfsg~beta1-2" version="1.10+dfsg~beta1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/krb5-locales" name="NEWS.Debian.gz"/>
     <File location="/usr/share/doc/krb5-locales" name="copyright"/>
@@ -6111,7 +6111,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="language-pack-en" uniqueId="Ubuntu_12.04-i686-language-pack-en-1:12.04+20120801" version="1:12.04+20120801" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/language-pack-en" name="copyright"/>
     <File location="/usr/share/doc/language-pack-en" name="changelog.gz"/>
@@ -6120,7 +6120,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="language-pack-en-base" uniqueId="Ubuntu_12.04-i686-language-pack-en-base-1:12.04+20120801" version="1:12.04+20120801" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/language-pack-en-base" name="copyright"/>
     <File location="/usr/share/doc/language-pack-en-base" name="changelog.gz"/>
@@ -6700,7 +6700,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="language-pack-gnome-en" uniqueId="Ubuntu_12.04-i686-language-pack-gnome-en-1:12.04+20120801" version="1:12.04+20120801" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/language-pack-gnome-en" name="copyright"/>
     <File location="/usr/share/doc/language-pack-gnome-en" name="changelog.gz"/>
@@ -6709,7 +6709,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="language-pack-gnome-en-base" uniqueId="Ubuntu_12.04-i686-language-pack-gnome-en-base-1:12.04+20120801" version="1:12.04+20120801" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/language-pack-gnome-en-base" name="changelog.gz"/>
     <File location="/usr/share/doc/language-pack-gnome-en-base" name="copyright"/>
@@ -8655,7 +8655,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="language-selector-common" uniqueId="Ubuntu_12.04-i686-language-selector-common-0.79" version="0.79" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dbus-1/system.d" name="com.ubuntu.LanguageSelector.conf"/>
     <File location="/etc/fonts/conf.avail" name="69-language-selector-zh-tw.conf"/>
@@ -8838,7 +8838,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="laptop-detect" uniqueId="Ubuntu_12.04-i686-laptop-detect-0.13.7ubuntu2" version="0.13.7ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="laptop-detect"/>
     <File location="/usr/share/doc/laptop-detect" name="README"/>
@@ -8850,7 +8850,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="less" uniqueId="Ubuntu_12.04-i686-less-444-1ubuntu1" version="444-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="less"/>
     <File location="/bin" name="lesskey"/>
@@ -8877,7 +8877,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libaccountsservice0" uniqueId="Ubuntu_12.04-i686-libaccountsservice0-0.6.15-2ubuntu9" version="0.6.15-2ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libaccountsservice.so.0.0.0"/>
     <File location="/usr/share/doc/libaccountsservice0" name="copyright"/>
@@ -8888,7 +8888,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libacl1" uniqueId="Ubuntu_12.04-i686-libacl1-2.2.51-5ubuntu1" version="2.2.51-5ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libacl.so.1.1.0"/>
     <File location="/usr/share/doc/libacl1" name="copyright"/>
@@ -8899,7 +8899,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libapt-inst1.4" uniqueId="Ubuntu_12.04-i686-libapt-inst1.4-0.8.16~exp12ubuntu10" version="0.8.16~exp12ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libapt-inst1.4" name="copyright"/>
     <File location="/usr/share/locale/ne/LC_MESSAGES" name="libapt-inst1.4.mo"/>
@@ -8953,7 +8953,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libapt-pkg4.12" uniqueId="Ubuntu_12.04-i686-libapt-pkg4.12-0.8.16~exp12ubuntu10" version="0.8.16~exp12ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libapt-pkg4.12" name="NEWS.Debian.gz"/>
     <File location="/usr/share/doc/libapt-pkg4.12" name="copyright"/>
@@ -9007,7 +9007,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libasn1-8-heimdal" uniqueId="Ubuntu_12.04-i686-libasn1-8-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libasn1.so.8.0.0"/>
     <File location="/usr/share/doc/libasn1-8-heimdal" name="copyright"/>
@@ -9019,7 +9019,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libattr1" uniqueId="Ubuntu_12.04-i686-libattr1-1:2.4.46-5ubuntu1" version="1:2.4.46-5ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libattr1" name="copyright"/>
     <File location="/usr/share/doc/libattr1" name="changelog.Debian.gz"/>
@@ -9030,7 +9030,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libbind9-80" uniqueId="Ubuntu_12.04-i686-libbind9-80-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libbind9-80" name="copyright"/>
     <File location="/usr/lib" name="libbind9.so.80.0.3"/>
@@ -9041,7 +9041,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libblkid1" uniqueId="Ubuntu_12.04-i686-libblkid1-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libblkid1" name="copyright"/>
     <File location="/lib/i386-linux-gnu" name="libblkid.so.1.1.0"/>
@@ -9053,7 +9053,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libboost-iostreams1.46.1" uniqueId="Ubuntu_12.04-i686-libboost-iostreams1.46.1-1.46.1-7ubuntu3" version="1.46.1-7ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libboost_iostreams.so.1.46.1"/>
     <File location="/usr/share/doc/libboost-iostreams1.46.1" name="NEWS.Debian.gz"/>
@@ -9066,7 +9066,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libbsd0" uniqueId="Ubuntu_12.04-i686-libbsd0-0.3.0-2" version="0.3.0-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libbsd0" name="copyright"/>
     <File location="/usr/share/doc/libbsd0" name="changelog.Debian.gz"/>
@@ -9077,7 +9077,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libbz2-1.0" uniqueId="Ubuntu_12.04-i686-libbz2-1.0-1.0.6-1" version="1.0.6-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libbz2.so.1.0.4"/>
     <File location="/usr/share/doc/libbz2-1.0" name="copyright"/>
@@ -9089,7 +9089,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libc-bin" uniqueId="Ubuntu_12.04-i686-libc-bin-2.15-0ubuntu10" version="2.15-0ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/locale/C.UTF-8" name="LC_CTYPE"/>
     <File location="/usr/lib/locale/C.UTF-8" name="LC_NUMERIC"/>
@@ -9149,7 +9149,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libc-dev-bin" uniqueId="Ubuntu_12.04-i686-libc-dev-bin-2.15-0ubuntu10" version="2.15-0ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="gencat"/>
     <File location="/usr/bin" name="mtrace"/>
@@ -9169,7 +9169,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libc6" uniqueId="Ubuntu_12.04-i686-libc6-2.15-0ubuntu10" version="2.15-0ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/ld.so.conf.d" name="i686-linux-gnu.conf"/>
     <File location="/lib/i386-linux-gnu" name="ld-2.15.so"/>
@@ -9485,7 +9485,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libc6-dev" uniqueId="Ubuntu_12.04-i686-libc6-dev-2.15-0ubuntu10" version="2.15-0ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libanl.a"/>
     <File location="/usr/lib/i386-linux-gnu" name="libBrokenLocale.a"/>
@@ -9987,7 +9987,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcap-ng0" uniqueId="Ubuntu_12.04-i686-libcap-ng0-0.6.6-1ubuntu1" version="0.6.6-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libcap-ng0" name="copyright"/>
     <File location="/usr/share/doc/libcap-ng0" name="changelog.Debian.gz"/>
@@ -9998,7 +9998,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcap2" uniqueId="Ubuntu_12.04-i686-libcap2-1:2.22-1ubuntu3" version="1:2.22-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libcap.so.2.22"/>
     <File location="/usr/share/doc/libcap2" name="copyright"/>
@@ -10009,7 +10009,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libclass-accessor-perl" uniqueId="Ubuntu_12.04-i686-libclass-accessor-perl-0.34-1" version="0.34-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man3" name="Class::Accessor.3pm.gz"/>
     <File location="/usr/share/man/man3" name="Class::Accessor::Fast.3pm.gz"/>
@@ -10025,7 +10025,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libclass-isa-perl" uniqueId="Ubuntu_12.04-i686-libclass-isa-perl-0.36-3" version="0.36-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libclass-isa-perl" name="copyright"/>
     <File location="/usr/share/doc/libclass-isa-perl" name="README.gz"/>
@@ -10037,7 +10037,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcomerr2" uniqueId="Ubuntu_12.04-i686-libcomerr2-1.42-1ubuntu2" version="1.42-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libcom_err.so.2.1"/>
     <File location="/usr/share/doc/libcomerr2" name="copyright"/>
@@ -10048,7 +10048,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcurl3-gnutls" uniqueId="Ubuntu_12.04-i686-libcurl3-gnutls-7.22.0-3ubuntu4" version="7.22.0-3ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libcurl-gnutls.so.4.2.0"/>
     <File location="/usr/share/lintian/overrides" name="libcurl3-gnutls"/>
@@ -10070,7 +10070,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcwidget3" uniqueId="Ubuntu_12.04-i686-libcwidget3-0.5.16-3.1ubuntu1" version="0.5.16-3.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libcwidget.so.3.0.0"/>
     <File location="/usr/share/doc/libcwidget3" name="copyright"/>
@@ -10081,7 +10081,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdb5.1" uniqueId="Ubuntu_12.04-i686-libdb5.1-5.1.25-11build1" version="5.1.25-11build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="libdb5.1"/>
     <File location="/usr/share/doc/libdb5.1" name="copyright"/>
@@ -10093,7 +10093,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdbus-1-3" uniqueId="Ubuntu_12.04-i686-libdbus-1-3-1.4.18-1ubuntu1" version="1.4.18-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libdbus-1.so.3.5.8"/>
     <File location="/usr/share/doc/libdbus-1-3" name="NEWS.gz"/>
@@ -10108,7 +10108,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdbus-glib-1-2" uniqueId="Ubuntu_12.04-i686-libdbus-glib-1-2-0.98-1ubuntu1" version="0.98-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libdbus-glib-1.so.2.2.2"/>
     <File location="/usr/share/doc/libdbus-glib-1-2" name="AUTHORS"/>
@@ -10123,7 +10123,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdevmapper-event1.02.1" uniqueId="Ubuntu_12.04-i686-libdevmapper-event1.02.1-2:1.02.48-4ubuntu7" version="2:1.02.48-4ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libdevmapper-event.so.1.02.1"/>
     <File location="/usr/share/doc/libdevmapper-event1.02.1" name="copyright"/>
@@ -10133,7 +10133,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdevmapper1.02.1" uniqueId="Ubuntu_12.04-i686-libdevmapper1.02.1-2:1.02.48-4ubuntu7" version="2:1.02.48-4ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libdevmapper.so.1.02.1"/>
     <File location="/usr/share/doc/libdevmapper1.02.1" name="copyright"/>
@@ -10143,7 +10143,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdns81" uniqueId="Ubuntu_12.04-i686-libdns81-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libdns81" name="copyright"/>
     <File location="/usr/lib" name="libdns.so.81.3.1"/>
@@ -10154,7 +10154,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdrm-intel1" uniqueId="Ubuntu_12.04-i686-libdrm-intel1-2.4.32-1ubuntu1" version="2.4.32-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libdrm-intel1" name="copyright"/>
     <File location="/usr/lib/i386-linux-gnu" name="libdrm_intel.so.1.0.0"/>
@@ -10165,7 +10165,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdrm-nouveau1a" uniqueId="Ubuntu_12.04-i686-libdrm-nouveau1a-2.4.32-1ubuntu1" version="2.4.32-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="libdrm-nouveau1a"/>
     <File location="/usr/share/doc/libdrm-nouveau1a" name="copyright"/>
@@ -10177,7 +10177,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdrm-radeon1" uniqueId="Ubuntu_12.04-i686-libdrm-radeon1-2.4.32-1ubuntu1" version="2.4.32-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="libdrm-radeon1"/>
     <File location="/usr/share/doc/libdrm-radeon1" name="copyright"/>
@@ -10189,7 +10189,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdrm2" uniqueId="Ubuntu_12.04-i686-libdrm2-2.4.32-1ubuntu1" version="2.4.32-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libdrm2" name="copyright"/>
     <File location="/usr/share/doc/libdrm2" name="NEWS.Debian.gz"/>
@@ -10201,7 +10201,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libedit2" uniqueId="Ubuntu_12.04-i686-libedit2-2.11-20080614-3ubuntu2" version="2.11-20080614-3ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libedit.so.2.11"/>
     <File location="/usr/share/doc/libedit2" name="copyright"/>
@@ -10212,7 +10212,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libelf1" uniqueId="Ubuntu_12.04-i686-libelf1-0.152-1ubuntu3" version="0.152-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libelf1" name="copyright"/>
     <File location="/usr/share/doc/libelf1" name="changelog.Debian.gz"/>
@@ -10223,7 +10223,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libept1.4.12" uniqueId="Ubuntu_12.04-i686-libept1.4.12-1.0.6~exp1ubuntu1" version="1.0.6~exp1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libept1.4.12" name="README"/>
     <File location="/usr/share/doc/libept1.4.12" name="copyright"/>
@@ -10234,7 +10234,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liberror-perl" uniqueId="Ubuntu_12.04-i686-liberror-perl-0.17-1" version="0.17-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/perl5" name="Error.pm"/>
     <File location="/usr/share/perl5/Error" name="Simple.pm"/>
@@ -10249,7 +10249,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libevent-2.0-5" uniqueId="Ubuntu_12.04-i686-libevent-2.0-5-2.0.16-stable-1" version="2.0.16-stable-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libevent-2.0.so.5.1.4"/>
     <File location="/usr/share/doc/libevent-2.0-5" name="copyright"/>
@@ -10260,7 +10260,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libexpat1" uniqueId="Ubuntu_12.04-i686-libexpat1-2.0.1-7.2ubuntu1" version="2.0.1-7.2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libexpatw.so.1.5.2"/>
     <File location="/usr/share/doc/libexpat1" name="copyright"/>
@@ -10273,7 +10273,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libffi6" uniqueId="Ubuntu_12.04-i686-libffi6-3.0.11~rc1-5" version="3.0.11~rc1-5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libffi6" name="copyright"/>
     <File location="/usr/share/doc/libffi6" name="changelog.Debian.gz"/>
@@ -10284,7 +10284,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libfreetype6" uniqueId="Ubuntu_12.04-i686-libfreetype6-2.4.8-1ubuntu2" version="2.4.8-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libfreetype.so.6.8.0"/>
     <File location="/usr/share/doc/libfreetype6" name="changelog.Debian.gz"/>
@@ -10299,7 +10299,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libfribidi0" uniqueId="Ubuntu_12.04-i686-libfribidi0-0.19.2-1" version="0.19.2-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="fribidi"/>
     <File location="/usr/lib" name="libfribidi.so.0.3.1"/>
@@ -10317,7 +10317,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libfuse2" uniqueId="Ubuntu_12.04-i686-libfuse2-2.8.6-2ubuntu2" version="2.8.6-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libfuse.so.2.8.6"/>
     <File location="/lib" name="libulockmgr.so.1.0.1"/>
@@ -10338,7 +10338,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgcc1" uniqueId="Ubuntu_12.04-i686-libgcc1-1:4.6.3-1ubuntu5" version="1:4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="libgcc1"/>
     <File location="/lib/i386-linux-gnu" name="libgcc_s.so.1"/>
@@ -10347,7 +10347,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgcrypt11" uniqueId="Ubuntu_12.04-i686-libgcrypt11-1.5.0-3" version="1.5.0-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libgcrypt11" name="NEWS.gz"/>
     <File location="/usr/share/doc/libgcrypt11" name="TODO"/>
@@ -10363,7 +10363,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgdbm3" uniqueId="Ubuntu_12.04-i686-libgdbm3-1.8.3-10" version="1.8.3-10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libgdbm.so.3.0.0"/>
     <File location="/usr/lib/i386-linux-gnu" name="libgdbm_compat.so.3.0.0"/>
@@ -10378,7 +10378,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgeoip1" uniqueId="Ubuntu_12.04-i686-libgeoip1-1.4.8+dfsg-2" version="1.4.8+dfsg-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libgeoip1" name="README.Debian-source"/>
     <File location="/usr/share/doc/libgeoip1" name="TODO"/>
@@ -10397,7 +10397,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgirepository-1.0-1" uniqueId="Ubuntu_12.04-i686-libgirepository-1.0-1-1.32.0-1" version="1.32.0-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libgirepository-1.0-1" name="README"/>
     <File location="/usr/share/doc/libgirepository-1.0-1" name="TODO"/>
@@ -10412,7 +10412,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libglib2.0-0" uniqueId="Ubuntu_12.04-i686-libglib2.0-0-2.32.1-0ubuntu2" version="2.32.1-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libgobject-2.0.so.0.3200.1"/>
     <File location="/usr/lib/i386-linux-gnu" name="libgmodule-2.0.so.0.3200.1"/>
@@ -10438,7 +10438,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgmp10" uniqueId="Ubuntu_12.04-i686-libgmp10-2:5.0.2+dfsg-2ubuntu1" version="2:5.0.2+dfsg-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libgmp10" name="copyright"/>
     <File location="/usr/share/doc/libgmp10" name="README.Debian"/>
@@ -10451,7 +10451,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgnutls26" uniqueId="Ubuntu_12.04-i686-libgnutls26-2.12.14-5ubuntu3" version="2.12.14-5ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libgnutls26" name="NEWS.gz"/>
     <File location="/usr/share/doc/libgnutls26" name="THANKS.gz"/>
@@ -10469,7 +10469,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgomp1" uniqueId="Ubuntu_12.04-i686-libgomp1-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libgomp.so.1.0.0"/>
     <File location="/usr/lib/i386-linux-gnu" name="libgomp.so.1"/>
@@ -10478,7 +10478,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgpg-error0" uniqueId="Ubuntu_12.04-i686-libgpg-error0-1.10-2ubuntu1" version="1.10-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libgpg-error.so.0.8.0"/>
     <File location="/usr/share/doc/libgpg-error0" name="README"/>
@@ -10491,7 +10491,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgssapi-krb5-2" uniqueId="Ubuntu_12.04-i686-libgssapi-krb5-2-1.10+dfsg~beta1-2" version="1.10+dfsg~beta1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libgssapi_krb5.so.2.2"/>
     <File location="/usr/share/doc/libgssapi-krb5-2" name="copyright"/>
@@ -10503,7 +10503,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgssapi3-heimdal" uniqueId="Ubuntu_12.04-i686-libgssapi3-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libgssapi.so.3.0.0"/>
     <File location="/usr/share/doc/libgssapi3-heimdal" name="copyright"/>
@@ -10515,7 +10515,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgssglue1" uniqueId="Ubuntu_12.04-i686-libgssglue1-0.3-4" version="0.3-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="gssapi_mech.conf"/>
     <File location="/usr/share/doc/libgssglue1" name="copyright"/>
@@ -10527,7 +10527,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libhcrypto4-heimdal" uniqueId="Ubuntu_12.04-i686-libhcrypto4-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libhcrypto.so.4.1.0"/>
     <File location="/usr/share/doc/libhcrypto4-heimdal" name="copyright"/>
@@ -10539,7 +10539,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libheimbase1-heimdal" uniqueId="Ubuntu_12.04-i686-libheimbase1-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libheimbase.so.1.0.0"/>
     <File location="/usr/share/doc/libheimbase1-heimdal" name="copyright"/>
@@ -10551,7 +10551,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libheimntlm0-heimdal" uniqueId="Ubuntu_12.04-i686-libheimntlm0-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libheimntlm.so.0.1.0"/>
     <File location="/usr/share/doc/libheimntlm0-heimdal" name="copyright"/>
@@ -10563,7 +10563,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libhx509-5-heimdal" uniqueId="Ubuntu_12.04-i686-libhx509-5-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libhx509.so.5.0.0"/>
     <File location="/usr/share/doc/libhx509-5-heimdal" name="copyright"/>
@@ -10575,7 +10575,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libidn11" uniqueId="Ubuntu_12.04-i686-libidn11-1.23-2" version="1.23-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libidn11" name="README"/>
     <File location="/usr/share/doc/libidn11" name="TODO"/>
@@ -10591,7 +10591,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libio-string-perl" uniqueId="Ubuntu_12.04-i686-libio-string-perl-1.08-2" version="1.08-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/perl5/IO" name="String.pm"/>
     <File location="/usr/share/man/man3" name="IO::String.3pm.gz"/>
@@ -10604,7 +10604,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libisc83" uniqueId="Ubuntu_12.04-i686-libisc83-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libisc83" name="copyright"/>
     <File location="/usr/share/doc/libisc83" name="changelog.Debian.gz"/>
@@ -10615,7 +10615,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libisccc80" uniqueId="Ubuntu_12.04-i686-libisccc80-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libisccc80" name="copyright"/>
     <File location="/usr/lib" name="libisccc.so.80.0.0"/>
@@ -10626,7 +10626,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libisccfg82" uniqueId="Ubuntu_12.04-i686-libisccfg82-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libisccfg82" name="copyright"/>
     <File location="/usr/lib" name="libisccfg.so.82.0.0"/>
@@ -10637,7 +10637,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libk5crypto3" uniqueId="Ubuntu_12.04-i686-libk5crypto3-1.10+dfsg~beta1-2" version="1.10+dfsg~beta1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libk5crypto.so.3.1"/>
     <File location="/usr/share/doc/libk5crypto3" name="copyright"/>
@@ -10649,7 +10649,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libkeyutils1" uniqueId="Ubuntu_12.04-i686-libkeyutils1-1.5.2-2" version="1.5.2-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libkeyutils.so.1.4"/>
     <File location="/usr/share/doc/libkeyutils1" name="copyright"/>
@@ -10660,7 +10660,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libklibc" uniqueId="Ubuntu_12.04-i686-libklibc-1.5.25-1ubuntu2" version="1.5.25-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="libklibc"/>
     <File location="/usr/share/doc/libklibc" name="README"/>
@@ -10675,7 +10675,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libkrb5-26-heimdal" uniqueId="Ubuntu_12.04-i686-libkrb5-26-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libkrb5.so.26.0.0"/>
     <File location="/usr/share/doc/libkrb5-26-heimdal" name="copyright"/>
@@ -10687,7 +10687,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libkrb5-3" uniqueId="Ubuntu_12.04-i686-libkrb5-3-1.10+dfsg~beta1-2" version="1.10+dfsg~beta1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libkrb5.so.3.3"/>
     <File location="/usr/share/doc/libkrb5-3" name="README.gz"/>
@@ -10702,7 +10702,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libkrb5support0" uniqueId="Ubuntu_12.04-i686-libkrb5support0-1.10+dfsg~beta1-2" version="1.10+dfsg~beta1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libkrb5support.so.0.1"/>
     <File location="/usr/share/doc/libkrb5support0" name="NEWS.Debian.gz"/>
@@ -10714,7 +10714,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libldap-2.4-2" uniqueId="Ubuntu_12.04-i686-libldap-2.4-2-2.4.28-1.1ubuntu4" version="2.4.28-1.1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="libldap-2.4-2"/>
     <File location="/usr/share/doc/libldap-2.4-2" name="copyright"/>
@@ -10732,7 +10732,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblocale-gettext-perl" uniqueId="Ubuntu_12.04-i686-liblocale-gettext-perl-1.05-7build1" version="1.05-7build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/Locale" name="gettext.pm"/>
     <File location="/usr/lib/perl5/auto/Locale/gettext" name="gettext.so"/>
@@ -10747,7 +10747,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblockfile-bin" uniqueId="Ubuntu_12.04-i686-liblockfile-bin-1.09-3" version="1.09-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="dotlockfile"/>
     <File location="/usr/share/lintian/overrides" name="liblockfile-bin"/>
@@ -10759,7 +10759,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblockfile1" uniqueId="Ubuntu_12.04-i686-liblockfile1-1.09-3" version="1.09-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/liblockfile1" name="copyright"/>
     <File location="/usr/share/doc/liblockfile1" name="changelog.Debian.gz"/>
@@ -10770,7 +10770,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblwres80" uniqueId="Ubuntu_12.04-i686-liblwres80-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/liblwres80" name="copyright"/>
     <File location="/usr/share/doc/liblwres80" name="changelog.Debian.gz"/>
@@ -10781,7 +10781,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblzma5" uniqueId="Ubuntu_12.04-i686-liblzma5-5.1.1alpha+20110809-3" version="5.1.1alpha+20110809-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/liblzma5" name="copyright"/>
     <File location="/usr/share/doc/liblzma5" name="THANKS"/>
@@ -10795,7 +10795,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmagic1" uniqueId="Ubuntu_12.04-i686-libmagic1-5.09-2" version="5.09-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/bug/libmagic1" name="control"/>
     <File location="/usr/share/bug/libmagic1" name="presubj"/>
@@ -10813,7 +10813,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmount1" uniqueId="Ubuntu_12.04-i686-libmount1-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libmount1" name="copyright"/>
     <File location="/lib/i386-linux-gnu" name="libmount.so.1.1.0"/>
@@ -10824,7 +10824,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmpc2" uniqueId="Ubuntu_12.04-i686-libmpc2-0.9-4" version="0.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libmpc.so.2.0.0"/>
     <File location="/usr/share/doc/libmpc2" name="copyright"/>
@@ -10835,7 +10835,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmpfr4" uniqueId="Ubuntu_12.04-i686-libmpfr4-3.1.0-3ubuntu2" version="3.1.0-3ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libmpfr.so.4.1.0"/>
     <File location="/usr/share/doc/libmpfr4" name="NEWS.gz"/>
@@ -10852,7 +10852,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libncurses5" uniqueId="Ubuntu_12.04-i686-libncurses5-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libncurses5" name="copyright"/>
     <File location="/usr/share/doc/libncurses5" name="FAQ"/>
@@ -10871,7 +10871,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libncursesw5" uniqueId="Ubuntu_12.04-i686-libncursesw5-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libncursesw5" name="copyright"/>
     <File location="/usr/lib/i386-linux-gnu" name="libpanelw.so.5.9"/>
@@ -10888,7 +10888,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnewt0.52" uniqueId="Ubuntu_12.04-i686-libnewt0.52-0.52.11-2ubuntu10" version="0.52.11-2ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/newt" name="palette.ubuntu"/>
     <File location="/etc/newt" name="palette.original"/>
@@ -10901,7 +10901,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnfnetlink0" uniqueId="Ubuntu_12.04-i686-libnfnetlink0-1.0.0-1" version="1.0.0-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libnfnetlink0" name="copyright"/>
     <File location="/usr/share/doc/libnfnetlink0" name="changelog.Debian.gz"/>
@@ -10912,7 +10912,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnfsidmap2" uniqueId="Ubuntu_12.04-i686-libnfsidmap2-0.25-1ubuntu2" version="0.25-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man5" name="idmapd.conf.5.gz"/>
     <File location="/usr/share/doc/libnfsidmap2" name="copyright"/>
@@ -10927,7 +10927,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnih-dbus1" uniqueId="Ubuntu_12.04-i686-libnih-dbus1-1.0.3-4ubuntu9" version="1.0.3-4ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libnih-dbus.so.1.0.0"/>
     <File location="/lib/i386-linux-gnu" name="libnih-dbus.so.1"/>
@@ -10936,7 +10936,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnih1" uniqueId="Ubuntu_12.04-i686-libnih1-1.0.3-4ubuntu9" version="1.0.3-4ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libnih1" name="README"/>
     <File location="/usr/share/doc/libnih1" name="copyright"/>
@@ -10950,7 +10950,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnl-3-200" uniqueId="Ubuntu_12.04-i686-libnl-3-200-3.2.3-2ubuntu2" version="3.2.3-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libnl-3-200" name="copyright"/>
     <File location="/usr/share/doc/libnl-3-200" name="README.Debian"/>
@@ -10964,7 +10964,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnl-genl-3-200" uniqueId="Ubuntu_12.04-i686-libnl-genl-3-200-3.2.3-2ubuntu2" version="3.2.3-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libnl-genl-3-200" name="copyright"/>
     <File location="/lib" name="libnl-genl-3.so.200.3.0"/>
@@ -10975,7 +10975,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libopts25" uniqueId="Ubuntu_12.04-i686-libopts25-1:5.12-0.1ubuntu1" version="1:5.12-0.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libopts25" name="copyright"/>
     <File location="/usr/share/doc/libopts25" name="changelog.Debian.gz"/>
@@ -10986,7 +10986,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libp11-kit0" uniqueId="Ubuntu_12.04-i686-libp11-kit0-0.12-2ubuntu1" version="0.12-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libp11-kit.so.0.0.0"/>
     <File location="/usr/share/doc/libp11-kit0" name="copyright"/>
@@ -10998,7 +10998,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpam-modules" uniqueId="Ubuntu_12.04-i686-libpam-modules-1.1.3-7ubuntu2" version="1.1.3-7ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/security" name="access.conf"/>
     <File location="/etc/security" name="group.conf"/>
@@ -11109,7 +11109,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpam-modules-bin" uniqueId="Ubuntu_12.04-i686-libpam-modules-bin-1.1.3-7ubuntu2" version="1.1.3-7ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="unix_chkpwd"/>
     <File location="/sbin" name="unix_update"/>
@@ -11128,7 +11128,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpam-runtime" uniqueId="Ubuntu_12.04-i686-libpam-runtime-1.1.3-7ubuntu2" version="1.1.3-7ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="pam.conf"/>
     <File location="/etc/pam.d" name="other"/>
@@ -11160,7 +11160,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpam0g" uniqueId="Ubuntu_12.04-i686-libpam0g-1.1.3-7ubuntu2" version="1.1.3-7ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libpam.so.0.83.0"/>
     <File location="/lib/i386-linux-gnu" name="libpam_misc.so.0.82.0"/>
@@ -11181,7 +11181,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libparse-debianchangelog-perl" uniqueId="Ubuntu_12.04-i686-libparse-debianchangelog-perl-1.2.0-1ubuntu1" version="1.2.0-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="parsechangelog"/>
     <File location="/usr/share/man/de/man3" name="Parse::DebianChangelog::Entry.3pm.gz"/>
@@ -11212,7 +11212,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libparted0debian1" uniqueId="Ubuntu_12.04-i686-libparted0debian1-2.3-8ubuntu5" version="2.3-8ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libparted.so.0.0.1"/>
     <File location="/usr/share/doc/libparted0debian1" name="copyright"/>
@@ -11224,7 +11224,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpcap0.8" uniqueId="Ubuntu_12.04-i686-libpcap0.8-1.1.1-10" version="1.1.1-10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libpcap.so.1.1.1"/>
     <File location="/usr/share/man/man7" name="pcap-filter.7.gz"/>
@@ -11239,7 +11239,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpci3" uniqueId="Ubuntu_12.04-i686-libpci3-1:3.1.8-2ubuntu5" version="1:3.1.8-2ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libpci3" name="copyright"/>
     <File location="/usr/share/doc/libpci3" name="changelog.Debian.gz"/>
@@ -11250,7 +11250,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpciaccess0" uniqueId="Ubuntu_12.04-i686-libpciaccess0-0.12.902-1" version="0.12.902-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libpciaccess0" name="copyright"/>
     <File location="/usr/share/doc/libpciaccess0" name="changelog.Debian.gz"/>
@@ -11261,7 +11261,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpcre3" uniqueId="Ubuntu_12.04-i686-libpcre3-8.12-4" version="8.12-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libpcre3" name="copyright"/>
     <File location="/usr/share/doc/libpcre3" name="README.gz"/>
@@ -11279,7 +11279,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpipeline1" uniqueId="Ubuntu_12.04-i686-libpipeline1-1.2.1-1" version="1.2.1-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libpipeline.so.1.2.1"/>
     <File location="/usr/share/doc/libpipeline1" name="copyright"/>
@@ -11290,7 +11290,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libplymouth2" uniqueId="Ubuntu_12.04-i686-libplymouth2-0.8.2-2ubuntu30" version="0.8.2-2ubuntu30" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libply.so.2.0.0"/>
     <File location="/lib" name="libply-boot-client.so.2.0.0"/>
@@ -11308,7 +11308,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpng12-0" uniqueId="Ubuntu_12.04-i686-libpng12-0-1.2.46-3ubuntu4" version="1.2.46-3ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libpng12-0" name="README.gz"/>
     <File location="/usr/share/doc/libpng12-0" name="TODO"/>
@@ -11326,7 +11326,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpolkit-gobject-1-0" uniqueId="Ubuntu_12.04-i686-libpolkit-gobject-1-0-0.104-1" version="0.104-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libpolkit-gobject-1.so.0.0.0"/>
     <File location="/usr/share/doc/libpolkit-gobject-1-0" name="copyright"/>
@@ -11337,7 +11337,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpopt0" uniqueId="Ubuntu_12.04-i686-libpopt0-1.16-3ubuntu1" version="1.16-3ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libpopt.so.0.0.0"/>
     <File location="/usr/share/doc/libpopt0" name="README"/>
@@ -11349,7 +11349,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libquadmath0" uniqueId="Ubuntu_12.04-i686-libquadmath0-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libquadmath.so.0.0.0"/>
     <File location="/usr/lib/i386-linux-gnu" name="libquadmath.so.0"/>
@@ -11358,13 +11358,13 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libreadline-dev" uniqueId="Ubuntu_12.04-i686-libreadline-dev-6.2-8" version="6.2-8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libreadline6" uniqueId="Ubuntu_12.04-i686-libreadline6-6.2-8" version="6.2-8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libhistory.so.6.2"/>
     <File location="/lib/i386-linux-gnu" name="libreadline.so.6.2"/>
@@ -11381,7 +11381,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libreadline6-dev" uniqueId="Ubuntu_12.04-i686-libreadline6-dev-6.2-8" version="6.2-8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libhistory.a"/>
     <File location="/usr/lib/i386-linux-gnu" name="libreadline.a"/>
@@ -11414,7 +11414,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libroken18-heimdal" uniqueId="Ubuntu_12.04-i686-libroken18-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libroken.so.18.1.0"/>
     <File location="/usr/share/doc/libroken18-heimdal" name="copyright"/>
@@ -11426,7 +11426,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="librtmp0" uniqueId="Ubuntu_12.04-i686-librtmp0-2.4~20110711.gitc28f1bab-1" version="2.4~20110711.gitc28f1bab-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="librtmp.so.0"/>
     <File location="/usr/share/doc/librtmp0" name="copyright"/>
@@ -11436,7 +11436,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsasl2-2" uniqueId="Ubuntu_12.04-i686-libsasl2-2-2.1.25.dfsg1-3" version="2.1.25.dfsg1-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/sasl2" name="berkeley_db.txt"/>
     <File location="/usr/lib/i386-linux-gnu" name="libsasl2.so.2.0.25"/>
@@ -11453,7 +11453,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsasl2-modules" uniqueId="Ubuntu_12.04-i686-libsasl2-modules-2.1.25.dfsg1-3" version="2.1.25.dfsg1-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu/sasl2" name="libanonymous.so.2.0.25"/>
     <File location="/usr/lib/i386-linux-gnu/sasl2" name="libcrammd5.so.2.0.25"/>
@@ -11481,7 +11481,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libselinux1" uniqueId="Ubuntu_12.04-i686-libselinux1-2.1.0-4.1ubuntu1" version="2.1.0-4.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libselinux.so.1"/>
     <File location="/usr/share/doc/libselinux1" name="copyright"/>
@@ -11492,7 +11492,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsigc++-2.0-0c2a" uniqueId="Ubuntu_12.04-i686-libsigc++-2.0-0c2a-2.2.10-0ubuntu2" version="2.2.10-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libsigc-2.0.so.0.0.0"/>
     <File location="/usr/share/doc/libsigc++-2.0-0c2a" name="copyright"/>
@@ -11503,7 +11503,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libslang2" uniqueId="Ubuntu_12.04-i686-libslang2-2.2.4-3ubuntu1" version="2.2.4-3ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="libslang2"/>
     <File location="/usr/share/doc/libslang2" name="README"/>
@@ -11520,7 +11520,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsqlite3-0" uniqueId="Ubuntu_12.04-i686-libsqlite3-0-3.7.9-2ubuntu1" version="3.7.9-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libsqlite3.so.0.8.6"/>
     <File location="/usr/share/doc/libsqlite3-0" name="README.Debian"/>
@@ -11532,7 +11532,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libss2" uniqueId="Ubuntu_12.04-i686-libss2-1.42-1ubuntu2" version="1.42-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libss.so.2.0"/>
     <File location="/usr/share/doc/libss2" name="copyright"/>
@@ -11543,7 +11543,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libssl-dev" uniqueId="Ubuntu_12.04-i686-libssl-dev-1.0.1-4ubuntu5.5" version="1.0.1-4ubuntu5.5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libcrypto.a"/>
     <File location="/usr/lib/i386-linux-gnu" name="libssl.a"/>
@@ -11632,7 +11632,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libssl-doc" uniqueId="Ubuntu_12.04-i686-libssl-doc-1.0.1-4ubuntu5.5" version="1.0.1-4ubuntu5.5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libssl-doc" name="copyright"/>
     <File location="/usr/share/doc/libssl-doc/demos/tunala" name="sm.c.gz"/>
@@ -12936,7 +12936,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libssl1.0.0" uniqueId="Ubuntu_12.04-i686-libssl1.0.0-1.0.1-4ubuntu5.5" version="1.0.1-4ubuntu5.5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libssl1.0.0" name="copyright"/>
     <File location="/usr/share/doc/libssl1.0.0" name="changelog.Debian.gz"/>
@@ -12959,7 +12959,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libstdc++6" uniqueId="Ubuntu_12.04-i686-libstdc++6-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libstdc++.so.6.0.16"/>
     <File location="/usr/lib/i386-linux-gnu" name="libstdc++.so.6"/>
@@ -12968,7 +12968,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsub-name-perl" uniqueId="Ubuntu_12.04-i686-libsub-name-perl-0.05-1build2" version="0.05-1build2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/Sub" name="Name.pm"/>
     <File location="/usr/lib/perl5/auto/Sub/Name" name="Name.so"/>
@@ -12981,7 +12981,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libswitch-perl" uniqueId="Ubuntu_12.04-i686-libswitch-perl-2.16-2" version="2.16-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man3" name="Switch.3pm.gz"/>
     <File location="/usr/share/perl5" name="Switch.pm"/>
@@ -12993,7 +12993,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtasn1-3" uniqueId="Ubuntu_12.04-i686-libtasn1-3-2.10-1ubuntu1" version="2.10-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libtasn1-3" name="README"/>
     <File location="/usr/share/doc/libtasn1-3" name="NEWS"/>
@@ -13008,7 +13008,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtext-charwidth-perl" uniqueId="Ubuntu_12.04-i686-libtext-charwidth-perl-0.04-7build1" version="0.04-7build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/Text" name="CharWidth.pm"/>
     <File location="/usr/lib/perl5/auto/Text/CharWidth" name="CharWidth.so"/>
@@ -13022,7 +13022,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtext-iconv-perl" uniqueId="Ubuntu_12.04-i686-libtext-iconv-perl-1.7-5" version="1.7-5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libtext-iconv-perl" name="copyright"/>
     <File location="/usr/share/doc/libtext-iconv-perl" name="changelog.Debian.gz"/>
@@ -13036,7 +13036,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtext-wrapi18n-perl" uniqueId="Ubuntu_12.04-i686-libtext-wrapi18n-perl-0.06-7" version="0.06-7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/perl5/Text" name="WrapI18N.pm"/>
     <File location="/usr/share/man/man3" name="Text::WrapI18N.3pm.gz"/>
@@ -13049,7 +13049,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtimedate-perl" uniqueId="Ubuntu_12.04-i686-libtimedate-perl-1.2000-1" version="1.2000-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man3" name="Date::Parse.3pm.gz"/>
     <File location="/usr/share/man/man3" name="Time::Zone.3pm.gz"/>
@@ -13100,7 +13100,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtinfo-dev" uniqueId="Ubuntu_12.04-i686-libtinfo-dev-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libtermcap.so"/>
     <File location="/usr/lib/i386-linux-gnu" name="libtic.a"/>
@@ -13116,7 +13116,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtinfo5" uniqueId="Ubuntu_12.04-i686-libtinfo5-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libtinfo5" name="copyright"/>
     <File location="/usr/share/doc/libtinfo5" name="changelog.Debian.gz"/>
@@ -13129,7 +13129,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtirpc1" uniqueId="Ubuntu_12.04-i686-libtirpc1-0.2.2-5" version="0.2.2-5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="netconfig"/>
     <File location="/usr/share/man/man5" name="netconfig.5.gz"/>
@@ -13142,7 +13142,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libudev0" uniqueId="Ubuntu_12.04-i686-libudev0-175-0ubuntu9" version="175-0ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libudev0" name="copyright"/>
     <File location="/usr/share/doc/libudev0" name="changelog.Debian.gz"/>
@@ -13153,7 +13153,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libusb-0.1-4" uniqueId="Ubuntu_12.04-i686-libusb-0.1-4-2:0.1.12-20" version="2:0.1.12-20" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libusb-0.1-4" name="copyright"/>
     <File location="/usr/share/doc/libusb-0.1-4" name="README.Debian"/>
@@ -13165,7 +13165,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libusb-1.0-0" uniqueId="Ubuntu_12.04-i686-libusb-1.0-0-2:1.0.9~rc3-2ubuntu1" version="2:1.0.9~rc3-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/i386-linux-gnu" name="libusb-1.0.so.0.1.0"/>
     <File location="/usr/share/doc/libusb-1.0-0" name="README"/>
@@ -13178,7 +13178,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libuuid1" uniqueId="Ubuntu_12.04-i686-libuuid1-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libuuid1" name="copyright"/>
     <File location="/usr/share/doc/libuuid1" name="changelog.Debian.gz"/>
@@ -13189,7 +13189,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libwind0-heimdal" uniqueId="Ubuntu_12.04-i686-libwind0-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libwind.so.0.0.0"/>
     <File location="/usr/share/doc/libwind0-heimdal" name="copyright"/>
@@ -13201,7 +13201,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libwrap0" uniqueId="Ubuntu_12.04-i686-libwrap0-7.6.q-21" version="7.6.q-21" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libwrap0" name="copyright"/>
     <File location="/usr/share/doc/libwrap0" name="README.gz"/>
@@ -13218,7 +13218,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libx11-6" uniqueId="Ubuntu_12.04-i686-libx11-6-2:1.4.99.1-0ubuntu2" version="2:1.4.99.1-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libx11-6" name="copyright"/>
     <File location="/usr/share/doc/libx11-6" name="NEWS.Debian.gz"/>
@@ -13232,7 +13232,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libx11-data" uniqueId="Ubuntu_12.04-i686-libx11-data-2:1.4.99.1-0ubuntu2" version="2:1.4.99.1-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libx11-data" name="copyright"/>
     <File location="/usr/share/doc/libx11-data" name="changelog.Debian.gz"/>
@@ -13427,7 +13427,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxapian22" uniqueId="Ubuntu_12.04-i686-libxapian22-1.2.8-1" version="1.2.8-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libxapian.so.22.4.2"/>
     <File location="/usr/lib/sse2" name="libxapian.so.22.4.2"/>
@@ -13441,7 +13441,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxau6" uniqueId="Ubuntu_12.04-i686-libxau6-1:1.0.6-4" version="1:1.0.6-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libxau6" name="copyright"/>
     <File location="/usr/share/doc/libxau6" name="changelog.Debian.gz"/>
@@ -13452,7 +13452,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxcb1" uniqueId="Ubuntu_12.04-i686-libxcb1-1.8.1-1" version="1.8.1-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libxcb.so.1.1.0"/>
     <File location="/usr/share/doc/libxcb1" name="copyright"/>
@@ -13463,7 +13463,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxdmcp6" uniqueId="Ubuntu_12.04-i686-libxdmcp6-1:1.1.0-4" version="1:1.1.0-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libxdmcp6" name="copyright"/>
     <File location="/usr/share/doc/libxdmcp6" name="changelog.Debian.gz"/>
@@ -13474,7 +13474,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxext6" uniqueId="Ubuntu_12.04-i686-libxext6-2:1.3.0-3build1" version="2:1.3.0-3build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libxext6" name="copyright"/>
     <File location="/usr/share/doc/libxext6" name="changelog.Debian.gz"/>
@@ -13485,7 +13485,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxml2" uniqueId="Ubuntu_12.04-i686-libxml2-2.7.8.dfsg-5.1ubuntu4" version="2.7.8.dfsg-5.1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/i386-linux-gnu" name="libxml2.so.2.7.8"/>
     <File location="/usr/share/doc/libxml2" name="AUTHORS"/>
@@ -13501,7 +13501,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxmuu1" uniqueId="Ubuntu_12.04-i686-libxmuu1-2:1.1.0-3" version="2:1.1.0-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/libxmuu1" name="copyright"/>
     <File location="/usr/share/doc/libxmuu1" name="changelog.Debian.gz"/>
@@ -13512,7 +13512,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-firmware" uniqueId="Ubuntu_12.04-i686-linux-firmware-1.79" version="1.79" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/firmware/3com" name="3C359.bin"/>
     <File location="/lib/firmware/3com" name="typhoon.bin"/>
@@ -14100,7 +14100,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-generic-pae" uniqueId="Ubuntu_12.04-i686-linux-generic-pae-3.2.0.23.25" version="3.2.0.23.25" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/linux-generic-pae" name="copyright"/>
     <File location="/usr/share/doc/linux-generic-pae" name="changelog.gz"/>
@@ -14109,7 +14109,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-image-3.2.0-23-generic-pae" uniqueId="Ubuntu_12.04-i686-linux-image-3.2.0-23-generic-pae-3.2.0-23.36" version="3.2.0-23.36" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/boot" name="vmlinuz-3.2.0-23-generic-pae"/>
     <File location="/boot" name="config-3.2.0-23-generic-pae"/>
@@ -17774,7 +17774,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-image-generic-pae" uniqueId="Ubuntu_12.04-i686-linux-image-generic-pae-3.2.0.23.25" version="3.2.0.23.25" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/linux-image-generic-pae" name="copyright"/>
     <File location="/usr/share/doc/linux-image-generic-pae" name="changelog.gz"/>
@@ -17783,7 +17783,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-libc-dev" uniqueId="Ubuntu_12.04-i686-linux-libc-dev-3.2.0-30.48" version="3.2.0-30.48" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include/linux" name="if_packet.h"/>
     <File location="/usr/include/linux" name="hpet.h"/>
@@ -18459,7 +18459,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="locales" uniqueId="Ubuntu_12.04-i686-locales-2.13+git20120306-3" version="2.13+git20120306-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/i18n" name="SUPPORTED"/>
     <File location="/usr/share/i18n/locales" name="de_LI"/>
@@ -19021,7 +19021,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lockfile-progs" uniqueId="Ubuntu_12.04-i686-lockfile-progs-0.1.16" version="0.1.16" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="lockfile-check"/>
     <File location="/usr/bin" name="lockfile-create"/>
@@ -19046,7 +19046,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="login" uniqueId="Ubuntu_12.04-i686-login-1:4.1.4.2+svn3283-3ubuntu5" version="1:4.1.4.2+svn3283-3ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="login"/>
     <File location="/usr/share/doc/login" name="README"/>
@@ -19151,7 +19151,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="logrotate" uniqueId="Ubuntu_12.04-i686-logrotate-3.7.8-6ubuntu5" version="3.7.8-6ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="logrotate"/>
     <File location="/usr/share/man/man8" name="logrotate.8.gz"/>
@@ -19166,7 +19166,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lsb-base" uniqueId="Ubuntu_12.04-i686-lsb-base-4.0-0ubuntu20" version="4.0-0ubuntu20" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/lsb" name="init-functions"/>
     <File location="/etc" name="lsb-base-logging.sh"/>
@@ -19178,7 +19178,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lsb-release" uniqueId="Ubuntu_12.04-i686-lsb-release-4.0-0ubuntu20" version="4.0-0ubuntu20" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="lsb_release"/>
     <File location="/usr/share/bug" name="lsb-release"/>
@@ -19194,7 +19194,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lshw" uniqueId="Ubuntu_12.04-i686-lshw-02.15-2" version="02.15-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="lshw"/>
     <File location="/usr/share/man/man1" name="lshw.1.gz"/>
@@ -19205,7 +19205,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lsof" uniqueId="Ubuntu_12.04-i686-lsof-4.81.dfsg.1-1build1" version="4.81.dfsg.1-1build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="lsof"/>
     <File location="/usr/share/doc/lsof/examples" name="00MANIFEST"/>
@@ -19235,7 +19235,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ltrace" uniqueId="Ubuntu_12.04-i686-ltrace-0.5.3-2.1ubuntu2" version="0.5.3-2.1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="ltrace"/>
     <File location="/usr/share/doc/ltrace" name="README"/>
@@ -19250,7 +19250,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lvm2" uniqueId="Ubuntu_12.04-i686-lvm2-2.02.66-4ubuntu7" version="2.02.66-4ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/udev/rules.d" name="56-lvm.rules"/>
     <File location="/lib/udev/rules.d" name="85-lvm2.rules"/>
@@ -19360,7 +19360,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="makedev" uniqueId="Ubuntu_12.04-i686-makedev-2.3.1-89ubuntu2" version="2.3.1-89ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="makedev"/>
     <File location="/usr/share/doc/makedev" name="copyright"/>
@@ -19372,7 +19372,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="man-db" uniqueId="Ubuntu_12.04-i686-man-db-2.6.1-2" version="2.6.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="manpath.config"/>
     <File location="/etc/cron.daily" name="man-db"/>
@@ -19522,7 +19522,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="manpages" uniqueId="Ubuntu_12.04-i686-manpages-3.35-0.1ubuntu1" version="3.35-0.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="manpages"/>
     <File location="/usr/share/doc/manpages" name="copyright"/>
@@ -19766,7 +19766,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="manpages-dev" uniqueId="Ubuntu_12.04-i686-manpages-dev-3.35-0.1ubuntu1" version="3.35-0.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="manpages-dev"/>
     <File location="/usr/share/man/man2" name="sched_yield.2.gz"/>
@@ -21627,7 +21627,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mawk" uniqueId="Ubuntu_12.04-i686-mawk-1.3.3-17" version="1.3.3-17" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="mawk"/>
     <File location="/usr/share/man/man1" name="mawk.1.gz"/>
@@ -21650,7 +21650,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="memtest86+" uniqueId="Ubuntu_12.04-i686-memtest86+-4.20-1.1ubuntu1" version="4.20-1.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/boot" name="memtest86+_multiboot.bin"/>
     <File location="/boot" name="memtest86+.bin"/>
@@ -21669,7 +21669,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mime-support" uniqueId="Ubuntu_12.04-i686-mime-support-3.51-1ubuntu1" version="3.51-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="mime.types"/>
     <File location="/etc" name="mailcap.order"/>
@@ -21701,7 +21701,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mlocate" uniqueId="Ubuntu_12.04-i686-mlocate-0.23.1-1ubuntu2" version="0.23.1-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="updatedb.conf"/>
     <File location="/etc/cron.daily" name="mlocate"/>
@@ -21722,7 +21722,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="module-init-tools" uniqueId="Ubuntu_12.04-i686-module-init-tools-3.16-1ubuntu2" version="3.16-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="lsmod"/>
     <File location="/sbin" name="insmod"/>
@@ -21761,7 +21761,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mount" uniqueId="Ubuntu_12.04-i686-mount-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="mount"/>
     <File location="/bin" name="umount"/>
@@ -21786,7 +21786,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mountall" uniqueId="Ubuntu_12.04-i686-mountall-2.36" version="2.36" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dbus-1/system.d" name="Mountall.Server.conf"/>
     <File location="/etc/init" name="mountall.conf"/>
@@ -21819,7 +21819,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mtr-tiny" uniqueId="Ubuntu_12.04-i686-mtr-tiny-0.80-1ubuntu1" version="0.80-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="mtr"/>
     <File location="/usr/share/doc/mtr-tiny" name="copyright"/>
@@ -21830,7 +21830,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="multiarch-support" uniqueId="Ubuntu_12.04-i686-multiarch-support-2.15-0ubuntu10" version="2.15-0ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/multiarch-support" name="copyright"/>
     <File location="/usr/share/doc/multiarch-support" name="changelog.Debian.gz"/>
@@ -21839,7 +21839,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nano" uniqueId="Ubuntu_12.04-i686-nano-2.2.6-1" version="2.2.6-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="nano"/>
     <File location="/usr/share/info" name="nano.info.gz"/>
@@ -21898,7 +21898,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses-base" uniqueId="Ubuntu_12.04-i686-ncurses-base-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="ncurses-base"/>
     <File location="/usr/share/tabset" name="vt300"/>
@@ -21952,7 +21952,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses-bin" uniqueId="Ubuntu_12.04-i686-ncurses-bin-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="clear"/>
     <File location="/usr/bin" name="tput"/>
@@ -21989,7 +21989,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="net-tools" uniqueId="Ubuntu_12.04-i686-net-tools-1.60-24.1ubuntu2" version="1.60-24.1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="netstat"/>
     <File location="/sbin" name="ifconfig"/>
@@ -22043,7 +22043,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="netbase" uniqueId="Ubuntu_12.04-i686-netbase-4.47ubuntu1" version="4.47ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="protocols"/>
     <File location="/etc" name="rpc"/>
@@ -22057,7 +22057,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="netcat-openbsd" uniqueId="Ubuntu_12.04-i686-netcat-openbsd-1.89-4ubuntu1" version="1.89-4ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="nc.openbsd"/>
     <File location="/usr/share/man/man1" name="nc_openbsd.1.gz"/>
@@ -22082,7 +22082,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nfs-common" uniqueId="Ubuntu_12.04-i686-nfs-common-1:1.2.5-3ubuntu3" version="1:1.2.5-3ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/init" name="statd.conf"/>
     <File location="/etc/init" name="statd-mounting.conf"/>
@@ -22145,7 +22145,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ntfs-3g" uniqueId="Ubuntu_12.04-i686-ntfs-3g-1:2012.1.15AR.1-1ubuntu1" version="1:2012.1.15AR.1-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/initramfs-tools/hooks" name="ntfs_3g"/>
     <File location="/usr/share/initramfs-tools/scripts/local-premount" name="ntfs_3g"/>
@@ -22214,7 +22214,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ntp" uniqueId="Ubuntu_12.04-i686-ntp-1:4.2.6.p3+dfsg-1ubuntu3.1" version="1:4.2.6.p3+dfsg-1ubuntu3.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/cron.daily" name="ntp"/>
     <File location="/etc/apparmor.d/tunables" name="ntpd"/>
@@ -22258,7 +22258,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ntpdate" uniqueId="Ubuntu_12.04-i686-ntpdate-1:4.2.6.p3+dfsg-1ubuntu3" version="1:4.2.6.p3+dfsg-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dhcp/dhclient-exit-hooks.d" name="ntpdate"/>
     <File location="/etc/default" name="ntpdate"/>
@@ -22277,7 +22277,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssh-client" uniqueId="Ubuntu_12.04-i686-openssh-client-1:5.9p1-5ubuntu1" version="1:5.9p1-5ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="openssh-client"/>
     <File location="/usr/share/man/man1" name="ssh-add.1.gz"/>
@@ -22326,7 +22326,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssh-server" uniqueId="Ubuntu_12.04-i686-openssh-server-1:5.9p1-5ubuntu1" version="1:5.9p1-5ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/init" name="ssh.conf"/>
     <File location="/etc/init.d" name="ssh"/>
@@ -22349,7 +22349,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssl" uniqueId="Ubuntu_12.04-i686-openssl-1.0.1-4ubuntu3" version="1.0.1-4ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="c_rehash"/>
     <File location="/usr/bin" name="openssl"/>
@@ -22438,7 +22438,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="os-prober" uniqueId="Ubuntu_12.04-i686-os-prober-1.51ubuntu3" version="1.51ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="os-prober"/>
     <File location="/usr/bin" name="linux-boot-prober"/>
@@ -22470,7 +22470,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="parted" uniqueId="Ubuntu_12.04-i686-parted-2.3-8ubuntu5" version="2.3-8ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="parted"/>
     <File location="/sbin" name="partprobe"/>
@@ -22485,7 +22485,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="passwd" uniqueId="Ubuntu_12.04-i686-passwd-1:4.1.4.2+svn3283-3ubuntu5" version="1:4.1.4.2+svn3283-3ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="passwd"/>
     <File location="/usr/share/doc/passwd" name="README"/>
@@ -22779,7 +22779,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="patch" uniqueId="Ubuntu_12.04-i686-patch-2.6.1-3" version="2.6.1-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="patch"/>
     <File location="/usr/share/man/man1" name="patch.1.gz"/>
@@ -22795,7 +22795,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pciutils" uniqueId="Ubuntu_12.04-i686-pciutils-1:3.1.8-2ubuntu5" version="1:3.1.8-2ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="pcimodules"/>
     <File location="/usr/bin" name="lspci"/>
@@ -22817,7 +22817,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl" uniqueId="Ubuntu_12.04-i686-perl-5.14.2-6ubuntu2" version="5.14.2-6ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="a2p"/>
     <File location="/usr/bin" name="pod2html"/>
@@ -23360,7 +23360,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-base" uniqueId="Ubuntu_12.04-i686-perl-base-5.14.2-6ubuntu2" version="5.14.2-6ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="perl"/>
     <File location="/usr/bin" name="perl5.14.2"/>
@@ -24319,7 +24319,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-modules" uniqueId="Ubuntu_12.04-i686-perl-modules-5.14.2-6ubuntu2" version="5.14.2-6ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/perl/5.14.2" name="version.pm"/>
     <File location="/usr/share/perl/5.14.2" name="getopts.pl"/>
@@ -24969,7 +24969,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="plymouth" uniqueId="Ubuntu_12.04-i686-plymouth-0.8.2-2ubuntu30" version="0.8.2-2ubuntu30" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="plymouth"/>
     <File location="/bin" name="plymouth-upstart-bridge"/>
@@ -25003,7 +25003,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="plymouth-theme-ubuntu-text" uniqueId="Ubuntu_12.04-i686-plymouth-theme-ubuntu-text-0.8.2-2ubuntu30" version="0.8.2-2ubuntu30" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/plymouth" name="ubuntu-text.so"/>
     <File location="/lib/plymouth/themes/ubuntu-text" name="ubuntu-text.plymouth.in"/>
@@ -25014,7 +25014,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="popularity-contest" uniqueId="Ubuntu_12.04-i686-popularity-contest-1.53ubuntu1" version="1.53ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/popularity-contest" name="popcon-upload"/>
     <File location="/usr/share/popularity-contest" name="default.conf"/>
@@ -25041,7 +25041,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="powermgmt-base" uniqueId="Ubuntu_12.04-i686-powermgmt-base-1.31" version="1.31" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="on_ac_power"/>
     <File location="/sbin" name="apm_available"/>
@@ -25058,7 +25058,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ppp" uniqueId="Ubuntu_12.04-i686-ppp-2.4.5-5ubuntu1" version="2.4.5-5ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/bash_completion.d" name="pon"/>
     <File location="/etc/ppp/ip-up.d" name="0000usepeerdns"/>
@@ -25164,7 +25164,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pppconfig" uniqueId="Ubuntu_12.04-i686-pppconfig-2.3.18+nmu3ubuntu1" version="2.3.18+nmu3ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/menu" name="pppconfig"/>
     <File location="/usr/share/doc/pppconfig" name="copyright"/>
@@ -25181,7 +25181,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pppoeconf" uniqueId="Ubuntu_12.04-i686-pppoeconf-1.20ubuntu1" version="1.20ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/pixmaps" name="pppoeconf.xpm"/>
     <File location="/usr/share/doc/pppoeconf" name="README.Debian"/>
@@ -25195,7 +25195,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="procps" uniqueId="Ubuntu_12.04-i686-procps-1:3.2.8-11ubuntu6" version="1:3.2.8-11ubuntu6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="sysctl.conf"/>
     <File location="/etc/sysctl.d" name="10-console-messages.conf"/>
@@ -25260,7 +25260,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="psmisc" uniqueId="Ubuntu_12.04-i686-psmisc-22.15-2ubuntu1" version="22.15-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="fuser"/>
     <File location="/usr/bin" name="killall"/>
@@ -25286,7 +25286,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python" uniqueId="Ubuntu_12.04-i686-python-2.7.3-0ubuntu2" version="2.7.3-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="dh_python2"/>
     <File location="/usr/share/python/runtime.d" name="public_modules.rtinstall"/>
@@ -25341,7 +25341,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-apt" uniqueId="Ubuntu_12.04-i686-python-apt-0.8.3ubuntu7" version="0.8.3ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/python-apt" name="README.templates"/>
     <File location="/usr/share/doc/python-apt" name="AUTHORS"/>
@@ -25393,7 +25393,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-apt-common" uniqueId="Ubuntu_12.04-i686-python-apt-common-0.8.3ubuntu7" version="0.8.3ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/python-apt-common" name="copyright"/>
     <File location="/usr/share/doc/python-apt-common" name="changelog.gz"/>
@@ -25410,7 +25410,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-chardet" uniqueId="Ubuntu_12.04-i686-python-chardet-2.0.1-2build1" version="2.0.1-2build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="chardet"/>
     <File location="/usr/share/pyshared" name="chardet-2.0.1.egg-info"/>
@@ -25509,7 +25509,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-configobj" uniqueId="Ubuntu_12.04-i686-python-configobj-4.7.2+ds-3build1" version="4.7.2+ds-3build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/python-configobj" name="configobj.html"/>
     <File location="/usr/share/doc/python-configobj" name="validate.txt.gz"/>
@@ -25575,7 +25575,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-dbus" uniqueId="Ubuntu_12.04-i686-python-dbus-1.0.0-1ubuntu1" version="1.0.0-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/pyshared/dbus" name="_expat_introspect_parser.py"/>
     <File location="/usr/share/pyshared/dbus" name="glib.py"/>
@@ -25626,7 +25626,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-dbus-dev" uniqueId="Ubuntu_12.04-i686-python-dbus-dev-1.0.0-1ubuntu1" version="1.0.0-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/python-dbus-dev" name="copyright"/>
     <File location="/usr/share/doc/python-dbus-dev" name="changelog.Debian.gz"/>
@@ -25637,7 +25637,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-debian" uniqueId="Ubuntu_12.04-i686-python-debian-0.1.21ubuntu1" version="0.1.21ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/python-debian" name="README.changelog.gz"/>
     <File location="/usr/share/doc/python-debian" name="README.debtags.gz"/>
@@ -25696,7 +25696,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-decorator" uniqueId="Ubuntu_12.04-i686-python-decorator-3.3.2-1" version="3.3.2-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/pyshared" name="decorator.py"/>
     <File location="/usr/share/pyshared/decorator-3.3.2.egg-info" name="top_level.txt"/>
@@ -25719,7 +25719,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-gdbm" uniqueId="Ubuntu_12.04-i686-python-gdbm-2.7.3-1ubuntu1" version="2.7.3-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/lib-dynload" name="gdbm.so"/>
     <File location="/usr/share/doc/python-gdbm" name="README.Debian"/>
@@ -25731,7 +25731,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-gi" uniqueId="Ubuntu_12.04-i686-python-gi-3.2.0-3" version="3.2.0-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/dist-packages/gi/_glib" name="_glib.so"/>
     <File location="/usr/lib/python2.7/dist-packages/gi/_gobject" name="_gobject.so"/>
@@ -25790,7 +25790,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-gnupginterface" uniqueId="Ubuntu_12.04-i686-python-gnupginterface-0.3.2-9.1ubuntu3" version="0.3.2-9.1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/python-gnupginterface" name="GnuPGInterface.html"/>
     <File location="/usr/share/doc/python-gnupginterface" name="README"/>
@@ -25808,7 +25808,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-minimal" uniqueId="Ubuntu_12.04-i686-python-minimal-2.7.3-0ubuntu2" version="2.7.3-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="pycompile"/>
     <File location="/usr/bin" name="pyclean"/>
@@ -25838,7 +25838,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-pexpect" uniqueId="Ubuntu_12.04-i686-python-pexpect-2.3-1ubuntu2" version="2.3-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/pyshared" name="fdpexpect.py"/>
     <File location="/usr/share/pyshared" name="FSM.py"/>
@@ -25898,7 +25898,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-simplegeneric" uniqueId="Ubuntu_12.04-i686-python-simplegeneric-0.7-1build1" version="0.7-1build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/python-simplegeneric" name="copyright"/>
     <File location="/usr/share/doc/python-simplegeneric" name="README.txt.gz"/>
@@ -25914,7 +25914,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-support" uniqueId="Ubuntu_12.04-i686-python-support-1.0.14ubuntu2" version="1.0.14ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/python-support/private" name="movemodules"/>
     <File location="/usr/share/python-support/private" name="parseversions"/>
@@ -25939,7 +25939,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-xapian" uniqueId="Ubuntu_12.04-i686-python-xapian-1.2.8-1" version="1.2.8-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/pyshared/xapian" name="__init__.py"/>
     <File location="/usr/share/doc-base" name="xapian-python-docs"/>
@@ -25958,7 +25958,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python2.7" uniqueId="Ubuntu_12.04-i686-python2.7-2.7.3-0ubuntu3" version="2.7.3-0ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/test" name="regrtest.py"/>
     <File location="/usr/lib/python2.7/test" name="test_support.py"/>
@@ -26469,7 +26469,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python2.7-minimal" uniqueId="Ubuntu_12.04-i686-python2.7-minimal-2.7.3-0ubuntu3" version="2.7.3-0ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/python2.7" name="sitecustomize.py"/>
     <File location="/usr/bin" name="python2.7"/>
@@ -26648,7 +26648,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="readline-common" uniqueId="Ubuntu_12.04-i686-readline-common-6.2-8" version="6.2-8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/readline" name="inputrc"/>
     <File location="/usr/share/info" name="rluserman.info.gz"/>
@@ -26663,7 +26663,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="resolvconf" uniqueId="Ubuntu_12.04-i686-resolvconf-1.63ubuntu11" version="1.63ubuntu11" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="resolvconf"/>
     <File location="/usr/share/doc/resolvconf" name="copyright"/>
@@ -26692,7 +26692,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpcbind" uniqueId="Ubuntu_12.04-i686-rpcbind-0.2.0-7ubuntu1.1" version="0.2.0-7ubuntu1.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="rpcbind"/>
     <File location="/usr/sbin" name="rpcinfo"/>
@@ -26712,7 +26712,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rsync" uniqueId="Ubuntu_12.04-i686-rsync-3.0.9-1ubuntu1" version="3.0.9-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="rsync"/>
     <File location="/usr/share/doc/rsync/examples" name="rsyncd.conf"/>
@@ -26745,7 +26745,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rsyslog" uniqueId="Ubuntu_12.04-i686-rsyslog-5.8.6-1ubuntu8" version="5.8.6-1ubuntu8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/apparmor.d" name="usr.sbin.rsyslogd"/>
     <File location="/etc" name="rsyslog.conf"/>
@@ -26796,7 +26796,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sed" uniqueId="Ubuntu_12.04-i686-sed-4.2.1-9" version="4.2.1-9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/sed/examples" name="dc.sed"/>
     <File location="/usr/share/doc/sed" name="BUGS.gz"/>
@@ -26815,7 +26815,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sensible-utils" uniqueId="Ubuntu_12.04-i686-sensible-utils-0.0.6ubuntu2" version="0.0.6ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="sensible-browser"/>
     <File location="/usr/bin" name="sensible-editor"/>
@@ -26842,7 +26842,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sgml-base" uniqueId="Ubuntu_12.04-i686-sgml-base-1.26+nmu1ubuntu1" version="1.26+nmu1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/sgml-base" name="catalog.super"/>
     <File location="/usr/share/sgml-base" name="catalog.centralized"/>
@@ -26862,7 +26862,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ssh-import-id" uniqueId="Ubuntu_12.04-i686-ssh-import-id-2.10-0ubuntu1" version="2.10-0ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="ssh-import-id"/>
     <File location="/usr/share/doc/ssh-import-id" name="copyright"/>
@@ -26874,7 +26874,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="strace" uniqueId="Ubuntu_12.04-i686-strace-4.5.20-2.3ubuntu1" version="4.5.20-2.3ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/strace" name="TODO"/>
     <File location="/usr/share/doc/strace" name="copyright"/>
@@ -26888,7 +26888,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sudo" uniqueId="Ubuntu_12.04-i686-sudo-1.8.3p1-1ubuntu3" version="1.8.3p1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pam.d" name="sudo"/>
     <File location="/etc/sudoers.d" name="README"/>
@@ -26930,7 +26930,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sysv-rc" uniqueId="Ubuntu_12.04-i686-sysv-rc-2.88dsf-13.10ubuntu11" version="2.88dsf-13.10ubuntu11" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="sysv-rc"/>
     <File location="/usr/share/sysv-rc" name="saveconfig"/>
@@ -26960,7 +26960,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sysvinit-utils" uniqueId="Ubuntu_12.04-i686-sysvinit-utils-2.88dsf-13.10ubuntu11" version="2.88dsf-13.10ubuntu11" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="last"/>
     <File location="/usr/bin" name="mesg"/>
@@ -26990,7 +26990,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tar" uniqueId="Ubuntu_12.04-i686-tar-1.26-4ubuntu1" version="1.26-4ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="tar"/>
     <File location="/usr/share/doc/tar" name="THANKS.gz"/>
@@ -27010,7 +27010,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tasksel" uniqueId="Ubuntu_12.04-i686-tasksel-2.88ubuntu9" version="2.88ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="tasksel"/>
     <File location="/usr/share/menu" name="tasksel"/>
@@ -27030,7 +27030,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tasksel-data" uniqueId="Ubuntu_12.04-i686-tasksel-data-2.88ubuntu9" version="2.88ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/tasksel-data" name="copyright"/>
     <File location="/usr/share/tasksel" name="ubuntu-tasks.desc"/>
@@ -27052,7 +27052,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tcpd" uniqueId="Ubuntu_12.04-i686-tcpd-7.6.q-21" version="7.6.q-21" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man8" name="safe_finger.8.gz"/>
     <File location="/usr/share/man/man8" name="tcpdmatch.8.gz"/>
@@ -27069,7 +27069,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tcpdump" uniqueId="Ubuntu_12.04-i686-tcpdump-4.2.1-1ubuntu2" version="4.2.1-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/apparmor.d" name="usr.sbin.tcpdump"/>
     <File location="/usr/sbin" name="tcpdump"/>
@@ -27087,7 +27087,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="telnet" uniqueId="Ubuntu_12.04-i686-telnet-0.17-36build1" version="0.17-36build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="telnet.netkit"/>
     <File location="/usr/share/doc/telnet" name="README.telnet"/>
@@ -27104,7 +27104,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="time" uniqueId="Ubuntu_12.04-i686-time-1.7-23.1" version="1.7-23.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/info" name="time.info.gz"/>
     <File location="/usr/share/doc/time" name="time.html"/>
@@ -27121,7 +27121,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tzdata" uniqueId="Ubuntu_12.04-i686-tzdata-2012b-1" version="2012b-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="tzconfig"/>
     <File location="/usr/share/zoneinfo/Africa" name="Algiers"/>
@@ -28921,7 +28921,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ubuntu-keyring" uniqueId="Ubuntu_12.04-i686-ubuntu-keyring-2011.11.21" version="2011.11.21" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/keyrings" name="ubuntu-master-keyring.gpg"/>
     <File location="/usr/share/keyrings" name="ubuntu-archive-keyring.gpg"/>
@@ -28934,7 +28934,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ubuntu-minimal" uniqueId="Ubuntu_12.04-i686-ubuntu-minimal-1.267" version="1.267" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/ubuntu-minimal" name="copyright"/>
     <File location="/usr/share/doc/ubuntu-minimal" name="changelog.gz"/>
@@ -28943,7 +28943,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ubuntu-standard" uniqueId="Ubuntu_12.04-i686-ubuntu-standard-1.267" version="1.267" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/ubuntu-standard" name="copyright"/>
     <File location="/usr/share/doc/ubuntu-standard" name="changelog.gz"/>
@@ -28952,7 +28952,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ucf" uniqueId="Ubuntu_12.04-i686-ucf-3.0025+nmu2ubuntu1" version="3.0025+nmu2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/lintian/overrides" name="ucf"/>
     <File location="/usr/share/man/man1" name="ucf.1.gz"/>
@@ -28974,7 +28974,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="udev" uniqueId="Ubuntu_12.04-i686-udev-175-0ubuntu9" version="175-0ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/apport/package-hooks" name="udev.py"/>
     <File location="/usr/share/initramfs-tools/hooks" name="udev"/>
@@ -29126,7 +29126,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ufw" uniqueId="Ubuntu_12.04-i686-ufw-0.31.1-1" version="0.31.1-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/bash_completion.d" name="ufw"/>
     <File location="/etc/logrotate.d" name="ufw"/>
@@ -29221,7 +29221,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="update-manager-core" uniqueId="Ubuntu_12.04-i686-update-manager-core-1:0.156.14" version="1:0.156.14" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/update-motd.d" name="91-release-upgrade"/>
     <File location="/etc/update-manager" name="release-upgrades"/>
@@ -29362,7 +29362,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="upstart" uniqueId="Ubuntu_12.04-i686-upstart-1.5-0ubuntu5" version="1.5-0ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dbus-1/system.d" name="Upstart.conf"/>
     <File location="/etc/init" name="upstart-socket-bridge.conf"/>
@@ -29451,7 +29451,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ureadahead" uniqueId="Ubuntu_12.04-i686-ureadahead-0.100.0-12" version="0.100.0-12" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/apport/package-hooks" name="ureadahead.py"/>
     <File location="/usr/share/man/man8" name="ureadahead.8.gz"/>
@@ -29465,7 +29465,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="usbutils" uniqueId="Ubuntu_12.04-i686-usbutils-1:005-1" version="1:005-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="lsusb"/>
     <File location="/usr/bin" name="usb-devices"/>
@@ -29485,7 +29485,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="util-linux" uniqueId="Ubuntu_12.04-i686-util-linux-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="more"/>
     <File location="/bin" name="tailf"/>
@@ -29635,7 +29635,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="uuid-runtime" uniqueId="Ubuntu_12.04-i686-uuid-runtime-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="uuidgen"/>
     <File location="/usr/share/lintian/overrides" name="uuid-runtime"/>
@@ -29649,7 +29649,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="vim-common" uniqueId="Ubuntu_12.04-i686-vim-common-2:7.3.429-2ubuntu2" version="2:7.3.429-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/vim" name="vimrc"/>
     <File location="/usr/bin" name="xxd"/>
@@ -29692,7 +29692,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="vim-tiny" uniqueId="Ubuntu_12.04-i686-vim-tiny-2:7.3.429-2ubuntu2" version="2:7.3.429-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/vim/vim73/doc" name="tags"/>
     <File location="/usr/share/vim/vim73/doc" name="help.txt"/>
@@ -29708,7 +29708,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="watershed" uniqueId="Ubuntu_12.04-i686-watershed-6" version="6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/initramfs-tools/hooks" name="watershed"/>
     <File location="/usr/share/doc/watershed" name="copyright"/>
@@ -29719,7 +29719,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="wget" uniqueId="Ubuntu_12.04-i686-wget-1.13.4-2ubuntu1" version="1.13.4-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="wgetrc"/>
     <File location="/usr/bin" name="wget"/>
@@ -29736,7 +29736,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="whiptail" uniqueId="Ubuntu_12.04-i686-whiptail-0.52.11-2ubuntu10" version="0.52.11-2ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="whiptail"/>
     <File location="/usr/share/doc/whiptail" name="README.whiptail"/>
@@ -29749,7 +29749,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="wireless-regdb" uniqueId="Ubuntu_12.04-i686-wireless-regdb-2011.04.28-1ubuntu3" version="2011.04.28-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/crda/pubkeys" name="ubuntu-devel-discuss@lists.ubuntu.com.key.pub.pem"/>
     <File location="/lib/crda" name="regulatory.bin"/>
@@ -29761,7 +29761,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xauth" uniqueId="Ubuntu_12.04-i686-xauth-1:1.0.6-1" version="1:1.0.6-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="xauth"/>
     <File location="/usr/share/man/man1" name="xauth.1.gz"/>
@@ -29772,7 +29772,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xkb-data" uniqueId="Ubuntu_12.04-i686-xkb-data-2.5-1ubuntu1" version="2.5-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man7" name="xkeyboard-config.7.gz"/>
     <File location="/usr/share/pkgconfig" name="xkeyboard-config.pc"/>
@@ -30115,7 +30115,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xml-core" uniqueId="Ubuntu_12.04-i686-xml-core-0.13" version="0.13" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/xml/schema/xml-core" name="catalog.dtd"/>
     <File location="/usr/share/xml/schema/xml-core" name="tr9401.dtd"/>
@@ -30145,7 +30145,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xz-lzma" uniqueId="Ubuntu_12.04-i686-xz-lzma-5.1.1alpha+20110809-3" version="5.1.1alpha+20110809-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/xz-lzma" name="copyright"/>
     <File location="/usr/share/doc/xz-lzma" name="changelog.Debian.gz"/>
@@ -30179,7 +30179,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xz-utils" uniqueId="Ubuntu_12.04-i686-xz-utils-5.1.1alpha+20110809-3" version="5.1.1alpha+20110809-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="xz"/>
     <File location="/usr/bin" name="xzless"/>
@@ -30220,7 +30220,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="zlib1g" uniqueId="Ubuntu_12.04-i686-zlib1g-1:1.2.3.4.dfsg-3ubuntu4" version="1:1.2.3.4.dfsg-3ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/zlib1g" name="copyright"/>
     <File location="/usr/share/doc/zlib1g" name="changelog.Debian.gz"/>
@@ -30231,7 +30231,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="zlib1g-dev" uniqueId="Ubuntu_12.04-i686-zlib1g-dev-1:1.2.3.4.dfsg-3ubuntu4" version="1:1.2.3.4.dfsg-3ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/zlib1g-dev" name="FAQ.gz"/>
     <File location="/usr/share/doc/zlib1g-dev/examples" name="zpipe.c.gz"/>

--- a/tests/dumps/swid_tags/dpkg-swid.txt
+++ b/tests/dumps/swid_tags/dpkg-swid.txt
@@ -1,1844 +1,1844 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="accountsservice" uniqueId="Ubuntu_12.04-i686-accountsservice-0.6.15-2ubuntu9" version="0.6.15-2ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="adduser" uniqueId="Ubuntu_12.04-i686-adduser-3.113ubuntu2" version="3.113ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="apparmor" uniqueId="Ubuntu_12.04-i686-apparmor-2.7.102-0ubuntu3" version="2.7.102-0ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="apt" uniqueId="Ubuntu_12.04-i686-apt-0.8.16~exp12ubuntu10" version="0.8.16~exp12ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="apt-transport-https" uniqueId="Ubuntu_12.04-i686-apt-transport-https-0.8.16~exp12ubuntu10" version="0.8.16~exp12ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="apt-utils" uniqueId="Ubuntu_12.04-i686-apt-utils-0.8.16~exp12ubuntu10" version="0.8.16~exp12ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="apt-xapian-index" uniqueId="Ubuntu_12.04-i686-apt-xapian-index-0.44ubuntu5" version="0.44ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="aptitude" uniqueId="Ubuntu_12.04-i686-aptitude-0.6.6-1ubuntu1" version="0.6.6-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="at" uniqueId="Ubuntu_12.04-i686-at-3.1.13-1ubuntu1" version="3.1.13-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="base-files" uniqueId="Ubuntu_12.04-i686-base-files-6.5ubuntu6" version="6.5ubuntu6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="base-passwd" uniqueId="Ubuntu_12.04-i686-base-passwd-3.5.24" version="3.5.24" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bash" uniqueId="Ubuntu_12.04-i686-bash-4.2-2ubuntu2" version="4.2-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bash-completion" uniqueId="Ubuntu_12.04-i686-bash-completion-1:1.3-1ubuntu8" version="1:1.3-1ubuntu8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bind9-host" uniqueId="Ubuntu_12.04-i686-bind9-host-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="binutils" uniqueId="Ubuntu_12.04-i686-binutils-2.22-6ubuntu1" version="2.22-6ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bsdmainutils" uniqueId="Ubuntu_12.04-i686-bsdmainutils-8.2.3ubuntu1" version="8.2.3ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bsdutils" uniqueId="Ubuntu_12.04-i686-bsdutils-1:2.20.1-1ubuntu3" version="1:2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="busybox-initramfs" uniqueId="Ubuntu_12.04-i686-busybox-initramfs-1:1.18.5-1ubuntu4" version="1:1.18.5-1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="busybox-static" uniqueId="Ubuntu_12.04-i686-busybox-static-1:1.18.5-1ubuntu4" version="1:1.18.5-1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bzip2" uniqueId="Ubuntu_12.04-i686-bzip2-1.0.6-1" version="1.0.6-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ca-certificates" uniqueId="Ubuntu_12.04-i686-ca-certificates-20111211" version="20111211" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="command-not-found" uniqueId="Ubuntu_12.04-i686-command-not-found-0.2.46ubuntu6" version="0.2.46ubuntu6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="command-not-found-data" uniqueId="Ubuntu_12.04-i686-command-not-found-data-0.2.46ubuntu6" version="0.2.46ubuntu6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="console-setup" uniqueId="Ubuntu_12.04-i686-console-setup-1.70ubuntu5" version="1.70ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="coreutils" uniqueId="Ubuntu_12.04-i686-coreutils-8.13-3ubuntu3" version="8.13-3ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cpio" uniqueId="Ubuntu_12.04-i686-cpio-2.11-7ubuntu3" version="2.11-7ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cpp" uniqueId="Ubuntu_12.04-i686-cpp-4:4.6.3-1ubuntu5" version="4:4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cpp-4.6" uniqueId="Ubuntu_12.04-i686-cpp-4.6-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="crda" uniqueId="Ubuntu_12.04-i686-crda-1.1.2-1ubuntu1" version="1.1.2-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cron" uniqueId="Ubuntu_12.04-i686-cron-3.0pl1-120ubuntu3" version="3.0pl1-120ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dash" uniqueId="Ubuntu_12.04-i686-dash-0.5.7-2ubuntu2" version="0.5.7-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dbus" uniqueId="Ubuntu_12.04-i686-dbus-1.4.18-1ubuntu1" version="1.4.18-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="debconf" uniqueId="Ubuntu_12.04-i686-debconf-1.5.42ubuntu1" version="1.5.42ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="debconf-i18n" uniqueId="Ubuntu_12.04-i686-debconf-i18n-1.5.42ubuntu1" version="1.5.42ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="debianutils" uniqueId="Ubuntu_12.04-i686-debianutils-4.2.1ubuntu2" version="4.2.1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="diffutils" uniqueId="Ubuntu_12.04-i686-diffutils-1:3.2-1ubuntu1" version="1:3.2-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dmidecode" uniqueId="Ubuntu_12.04-i686-dmidecode-2.11-4" version="2.11-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dmsetup" uniqueId="Ubuntu_12.04-i686-dmsetup-2:1.02.48-4ubuntu7" version="2:1.02.48-4ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dnsutils" uniqueId="Ubuntu_12.04-i686-dnsutils-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dosfstools" uniqueId="Ubuntu_12.04-i686-dosfstools-3.0.12-1ubuntu1" version="3.0.12-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dpkg" uniqueId="Ubuntu_12.04-i686-dpkg-1.16.1.2ubuntu7" version="1.16.1.2ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="e2fslibs" uniqueId="Ubuntu_12.04-i686-e2fslibs-1.42-1ubuntu2" version="1.42-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="e2fsprogs" uniqueId="Ubuntu_12.04-i686-e2fsprogs-1.42-1ubuntu2" version="1.42-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ed" uniqueId="Ubuntu_12.04-i686-ed-1.5-3" version="1.5-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="eject" uniqueId="Ubuntu_12.04-i686-eject-2.1.5+deb1+cvs20081104-9" version="2.1.5+deb1+cvs20081104-9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="file" uniqueId="Ubuntu_12.04-i686-file-5.09-2" version="5.09-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="findutils" uniqueId="Ubuntu_12.04-i686-findutils-4.4.2-4ubuntu1" version="4.4.2-4ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="friendly-recovery" uniqueId="Ubuntu_12.04-i686-friendly-recovery-0.2.25" version="0.2.25" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ftp" uniqueId="Ubuntu_12.04-i686-ftp-0.17-25" version="0.17-25" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="fuse" uniqueId="Ubuntu_12.04-i686-fuse-2.8.6-2ubuntu2" version="2.8.6-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gcc" uniqueId="Ubuntu_12.04-i686-gcc-4:4.6.3-1ubuntu5" version="4:4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gcc-4.6" uniqueId="Ubuntu_12.04-i686-gcc-4.6-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gcc-4.6-base" uniqueId="Ubuntu_12.04-i686-gcc-4.6-base-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="geoip-database" uniqueId="Ubuntu_12.04-i686-geoip-database-20111220-1" version="20111220-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gettext-base" uniqueId="Ubuntu_12.04-i686-gettext-base-0.18.1.1-5ubuntu3" version="0.18.1.1-5ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gir1.2-glib-2.0" uniqueId="Ubuntu_12.04-i686-gir1.2-glib-2.0-1.32.0-1" version="1.32.0-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="git" uniqueId="Ubuntu_12.04-i686-git-1:1.7.9.5-1" version="1:1.7.9.5-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="git-man" uniqueId="Ubuntu_12.04-i686-git-man-1:1.7.9.5-1" version="1:1.7.9.5-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gnupg" uniqueId="Ubuntu_12.04-i686-gnupg-1.4.11-3ubuntu2" version="1.4.11-3ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gpgv" uniqueId="Ubuntu_12.04-i686-gpgv-1.4.11-3ubuntu2" version="1.4.11-3ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grep" uniqueId="Ubuntu_12.04-i686-grep-2.10-1" version="2.10-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="groff-base" uniqueId="Ubuntu_12.04-i686-groff-base-1.21-7" version="1.21-7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grub-common" uniqueId="Ubuntu_12.04-i686-grub-common-1.99-21ubuntu3.1" version="1.99-21ubuntu3.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grub-gfxpayload-lists" uniqueId="Ubuntu_12.04-i686-grub-gfxpayload-lists-0.6" version="0.6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grub-pc" uniqueId="Ubuntu_12.04-i686-grub-pc-1.99-21ubuntu3.1" version="1.99-21ubuntu3.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grub-pc-bin" uniqueId="Ubuntu_12.04-i686-grub-pc-bin-1.99-21ubuntu3.1" version="1.99-21ubuntu3.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grub2-common" uniqueId="Ubuntu_12.04-i686-grub2-common-1.99-21ubuntu3.1" version="1.99-21ubuntu3.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gzip" uniqueId="Ubuntu_12.04-i686-gzip-1.4-1ubuntu2" version="1.4-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hdparm" uniqueId="Ubuntu_12.04-i686-hdparm-9.37-0ubuntu3" version="9.37-0ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hostname" uniqueId="Ubuntu_12.04-i686-hostname-3.06ubuntu1" version="3.06ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ifupdown" uniqueId="Ubuntu_12.04-i686-ifupdown-0.7~beta2ubuntu8" version="0.7~beta2ubuntu8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="info" uniqueId="Ubuntu_12.04-i686-info-4.13a.dfsg.1-8ubuntu2" version="4.13a.dfsg.1-8ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="initramfs-tools" uniqueId="Ubuntu_12.04-i686-initramfs-tools-0.99ubuntu13" version="0.99ubuntu13" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="initramfs-tools-bin" uniqueId="Ubuntu_12.04-i686-initramfs-tools-bin-0.99ubuntu13" version="0.99ubuntu13" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="initscripts" uniqueId="Ubuntu_12.04-i686-initscripts-2.88dsf-13.10ubuntu11" version="2.88dsf-13.10ubuntu11" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="insserv" uniqueId="Ubuntu_12.04-i686-insserv-1.14.0-2.1ubuntu2" version="1.14.0-2.1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="install-info" uniqueId="Ubuntu_12.04-i686-install-info-4.13a.dfsg.1-8ubuntu2" version="4.13a.dfsg.1-8ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="installation-report" uniqueId="Ubuntu_12.04-i686-installation-report-2.46ubuntu1" version="2.46ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iproute" uniqueId="Ubuntu_12.04-i686-iproute-20111117-1ubuntu2" version="20111117-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iptables" uniqueId="Ubuntu_12.04-i686-iptables-1.4.12-1ubuntu4" version="1.4.12-1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iputils-ping" uniqueId="Ubuntu_12.04-i686-iputils-ping-3:20101006-1ubuntu1" version="3:20101006-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iputils-tracepath" uniqueId="Ubuntu_12.04-i686-iputils-tracepath-3:20101006-1ubuntu1" version="3:20101006-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ipython" uniqueId="Ubuntu_12.04-i686-ipython-0.12.1+dfsg-0ubuntu1" version="0.12.1+dfsg-0ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="irqbalance" uniqueId="Ubuntu_12.04-i686-irqbalance-0.56-1ubuntu4" version="0.56-1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="isc-dhcp-client" uniqueId="Ubuntu_12.04-i686-isc-dhcp-client-4.1.ESV-R4-0ubuntu5" version="4.1.ESV-R4-0ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="isc-dhcp-common" uniqueId="Ubuntu_12.04-i686-isc-dhcp-common-4.1.ESV-R4-0ubuntu5" version="4.1.ESV-R4-0ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iso-codes" uniqueId="Ubuntu_12.04-i686-iso-codes-3.31-1" version="3.31-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kbd" uniqueId="Ubuntu_12.04-i686-kbd-1.15.2-3ubuntu4" version="1.15.2-3ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="keyboard-configuration" uniqueId="Ubuntu_12.04-i686-keyboard-configuration-1.70ubuntu5" version="1.70ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="klibc-utils" uniqueId="Ubuntu_12.04-i686-klibc-utils-1.5.25-1ubuntu2" version="1.5.25-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="krb5-locales" uniqueId="Ubuntu_12.04-i686-krb5-locales-1.10+dfsg~beta1-2" version="1.10+dfsg~beta1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="language-pack-en" uniqueId="Ubuntu_12.04-i686-language-pack-en-1:12.04+20120801" version="1:12.04+20120801" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="language-pack-en-base" uniqueId="Ubuntu_12.04-i686-language-pack-en-base-1:12.04+20120801" version="1:12.04+20120801" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="language-pack-gnome-en" uniqueId="Ubuntu_12.04-i686-language-pack-gnome-en-1:12.04+20120801" version="1:12.04+20120801" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="language-pack-gnome-en-base" uniqueId="Ubuntu_12.04-i686-language-pack-gnome-en-base-1:12.04+20120801" version="1:12.04+20120801" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="language-selector-common" uniqueId="Ubuntu_12.04-i686-language-selector-common-0.79" version="0.79" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="laptop-detect" uniqueId="Ubuntu_12.04-i686-laptop-detect-0.13.7ubuntu2" version="0.13.7ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="less" uniqueId="Ubuntu_12.04-i686-less-444-1ubuntu1" version="444-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libaccountsservice0" uniqueId="Ubuntu_12.04-i686-libaccountsservice0-0.6.15-2ubuntu9" version="0.6.15-2ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libacl1" uniqueId="Ubuntu_12.04-i686-libacl1-2.2.51-5ubuntu1" version="2.2.51-5ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libapt-inst1.4" uniqueId="Ubuntu_12.04-i686-libapt-inst1.4-0.8.16~exp12ubuntu10" version="0.8.16~exp12ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libapt-pkg4.12" uniqueId="Ubuntu_12.04-i686-libapt-pkg4.12-0.8.16~exp12ubuntu10" version="0.8.16~exp12ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libasn1-8-heimdal" uniqueId="Ubuntu_12.04-i686-libasn1-8-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libattr1" uniqueId="Ubuntu_12.04-i686-libattr1-1:2.4.46-5ubuntu1" version="1:2.4.46-5ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libbind9-80" uniqueId="Ubuntu_12.04-i686-libbind9-80-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libblkid1" uniqueId="Ubuntu_12.04-i686-libblkid1-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libboost-iostreams1.46.1" uniqueId="Ubuntu_12.04-i686-libboost-iostreams1.46.1-1.46.1-7ubuntu3" version="1.46.1-7ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libbsd0" uniqueId="Ubuntu_12.04-i686-libbsd0-0.3.0-2" version="0.3.0-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libbz2-1.0" uniqueId="Ubuntu_12.04-i686-libbz2-1.0-1.0.6-1" version="1.0.6-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libc-bin" uniqueId="Ubuntu_12.04-i686-libc-bin-2.15-0ubuntu10" version="2.15-0ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libc-dev-bin" uniqueId="Ubuntu_12.04-i686-libc-dev-bin-2.15-0ubuntu10" version="2.15-0ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libc6" uniqueId="Ubuntu_12.04-i686-libc6-2.15-0ubuntu10" version="2.15-0ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libc6-dev" uniqueId="Ubuntu_12.04-i686-libc6-dev-2.15-0ubuntu10" version="2.15-0ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcap-ng0" uniqueId="Ubuntu_12.04-i686-libcap-ng0-0.6.6-1ubuntu1" version="0.6.6-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcap2" uniqueId="Ubuntu_12.04-i686-libcap2-1:2.22-1ubuntu3" version="1:2.22-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libclass-accessor-perl" uniqueId="Ubuntu_12.04-i686-libclass-accessor-perl-0.34-1" version="0.34-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libclass-isa-perl" uniqueId="Ubuntu_12.04-i686-libclass-isa-perl-0.36-3" version="0.36-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcomerr2" uniqueId="Ubuntu_12.04-i686-libcomerr2-1.42-1ubuntu2" version="1.42-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcurl3-gnutls" uniqueId="Ubuntu_12.04-i686-libcurl3-gnutls-7.22.0-3ubuntu4" version="7.22.0-3ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcwidget3" uniqueId="Ubuntu_12.04-i686-libcwidget3-0.5.16-3.1ubuntu1" version="0.5.16-3.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdb5.1" uniqueId="Ubuntu_12.04-i686-libdb5.1-5.1.25-11build1" version="5.1.25-11build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdbus-1-3" uniqueId="Ubuntu_12.04-i686-libdbus-1-3-1.4.18-1ubuntu1" version="1.4.18-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdbus-glib-1-2" uniqueId="Ubuntu_12.04-i686-libdbus-glib-1-2-0.98-1ubuntu1" version="0.98-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdevmapper-event1.02.1" uniqueId="Ubuntu_12.04-i686-libdevmapper-event1.02.1-2:1.02.48-4ubuntu7" version="2:1.02.48-4ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdevmapper1.02.1" uniqueId="Ubuntu_12.04-i686-libdevmapper1.02.1-2:1.02.48-4ubuntu7" version="2:1.02.48-4ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdns81" uniqueId="Ubuntu_12.04-i686-libdns81-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdrm-intel1" uniqueId="Ubuntu_12.04-i686-libdrm-intel1-2.4.32-1ubuntu1" version="2.4.32-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdrm-nouveau1a" uniqueId="Ubuntu_12.04-i686-libdrm-nouveau1a-2.4.32-1ubuntu1" version="2.4.32-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdrm-radeon1" uniqueId="Ubuntu_12.04-i686-libdrm-radeon1-2.4.32-1ubuntu1" version="2.4.32-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdrm2" uniqueId="Ubuntu_12.04-i686-libdrm2-2.4.32-1ubuntu1" version="2.4.32-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libedit2" uniqueId="Ubuntu_12.04-i686-libedit2-2.11-20080614-3ubuntu2" version="2.11-20080614-3ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libelf1" uniqueId="Ubuntu_12.04-i686-libelf1-0.152-1ubuntu3" version="0.152-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libept1.4.12" uniqueId="Ubuntu_12.04-i686-libept1.4.12-1.0.6~exp1ubuntu1" version="1.0.6~exp1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liberror-perl" uniqueId="Ubuntu_12.04-i686-liberror-perl-0.17-1" version="0.17-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libevent-2.0-5" uniqueId="Ubuntu_12.04-i686-libevent-2.0-5-2.0.16-stable-1" version="2.0.16-stable-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libexpat1" uniqueId="Ubuntu_12.04-i686-libexpat1-2.0.1-7.2ubuntu1" version="2.0.1-7.2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libffi6" uniqueId="Ubuntu_12.04-i686-libffi6-3.0.11~rc1-5" version="3.0.11~rc1-5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libfreetype6" uniqueId="Ubuntu_12.04-i686-libfreetype6-2.4.8-1ubuntu2" version="2.4.8-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libfribidi0" uniqueId="Ubuntu_12.04-i686-libfribidi0-0.19.2-1" version="0.19.2-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libfuse2" uniqueId="Ubuntu_12.04-i686-libfuse2-2.8.6-2ubuntu2" version="2.8.6-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgcc1" uniqueId="Ubuntu_12.04-i686-libgcc1-1:4.6.3-1ubuntu5" version="1:4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgcrypt11" uniqueId="Ubuntu_12.04-i686-libgcrypt11-1.5.0-3" version="1.5.0-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgdbm3" uniqueId="Ubuntu_12.04-i686-libgdbm3-1.8.3-10" version="1.8.3-10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgeoip1" uniqueId="Ubuntu_12.04-i686-libgeoip1-1.4.8+dfsg-2" version="1.4.8+dfsg-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgirepository-1.0-1" uniqueId="Ubuntu_12.04-i686-libgirepository-1.0-1-1.32.0-1" version="1.32.0-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libglib2.0-0" uniqueId="Ubuntu_12.04-i686-libglib2.0-0-2.32.1-0ubuntu2" version="2.32.1-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgmp10" uniqueId="Ubuntu_12.04-i686-libgmp10-2:5.0.2+dfsg-2ubuntu1" version="2:5.0.2+dfsg-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgnutls26" uniqueId="Ubuntu_12.04-i686-libgnutls26-2.12.14-5ubuntu3" version="2.12.14-5ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgomp1" uniqueId="Ubuntu_12.04-i686-libgomp1-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgpg-error0" uniqueId="Ubuntu_12.04-i686-libgpg-error0-1.10-2ubuntu1" version="1.10-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgssapi-krb5-2" uniqueId="Ubuntu_12.04-i686-libgssapi-krb5-2-1.10+dfsg~beta1-2" version="1.10+dfsg~beta1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgssapi3-heimdal" uniqueId="Ubuntu_12.04-i686-libgssapi3-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgssglue1" uniqueId="Ubuntu_12.04-i686-libgssglue1-0.3-4" version="0.3-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libhcrypto4-heimdal" uniqueId="Ubuntu_12.04-i686-libhcrypto4-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libheimbase1-heimdal" uniqueId="Ubuntu_12.04-i686-libheimbase1-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libheimntlm0-heimdal" uniqueId="Ubuntu_12.04-i686-libheimntlm0-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libhx509-5-heimdal" uniqueId="Ubuntu_12.04-i686-libhx509-5-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libidn11" uniqueId="Ubuntu_12.04-i686-libidn11-1.23-2" version="1.23-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libio-string-perl" uniqueId="Ubuntu_12.04-i686-libio-string-perl-1.08-2" version="1.08-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libisc83" uniqueId="Ubuntu_12.04-i686-libisc83-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libisccc80" uniqueId="Ubuntu_12.04-i686-libisccc80-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libisccfg82" uniqueId="Ubuntu_12.04-i686-libisccfg82-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libk5crypto3" uniqueId="Ubuntu_12.04-i686-libk5crypto3-1.10+dfsg~beta1-2" version="1.10+dfsg~beta1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libkeyutils1" uniqueId="Ubuntu_12.04-i686-libkeyutils1-1.5.2-2" version="1.5.2-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libklibc" uniqueId="Ubuntu_12.04-i686-libklibc-1.5.25-1ubuntu2" version="1.5.25-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libkrb5-26-heimdal" uniqueId="Ubuntu_12.04-i686-libkrb5-26-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libkrb5-3" uniqueId="Ubuntu_12.04-i686-libkrb5-3-1.10+dfsg~beta1-2" version="1.10+dfsg~beta1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libkrb5support0" uniqueId="Ubuntu_12.04-i686-libkrb5support0-1.10+dfsg~beta1-2" version="1.10+dfsg~beta1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libldap-2.4-2" uniqueId="Ubuntu_12.04-i686-libldap-2.4-2-2.4.28-1.1ubuntu4" version="2.4.28-1.1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblocale-gettext-perl" uniqueId="Ubuntu_12.04-i686-liblocale-gettext-perl-1.05-7build1" version="1.05-7build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblockfile-bin" uniqueId="Ubuntu_12.04-i686-liblockfile-bin-1.09-3" version="1.09-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblockfile1" uniqueId="Ubuntu_12.04-i686-liblockfile1-1.09-3" version="1.09-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblwres80" uniqueId="Ubuntu_12.04-i686-liblwres80-1:9.8.1.dfsg.P1-4" version="1:9.8.1.dfsg.P1-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblzma5" uniqueId="Ubuntu_12.04-i686-liblzma5-5.1.1alpha+20110809-3" version="5.1.1alpha+20110809-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmagic1" uniqueId="Ubuntu_12.04-i686-libmagic1-5.09-2" version="5.09-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmount1" uniqueId="Ubuntu_12.04-i686-libmount1-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmpc2" uniqueId="Ubuntu_12.04-i686-libmpc2-0.9-4" version="0.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmpfr4" uniqueId="Ubuntu_12.04-i686-libmpfr4-3.1.0-3ubuntu2" version="3.1.0-3ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libncurses5" uniqueId="Ubuntu_12.04-i686-libncurses5-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libncursesw5" uniqueId="Ubuntu_12.04-i686-libncursesw5-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnewt0.52" uniqueId="Ubuntu_12.04-i686-libnewt0.52-0.52.11-2ubuntu10" version="0.52.11-2ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnfnetlink0" uniqueId="Ubuntu_12.04-i686-libnfnetlink0-1.0.0-1" version="1.0.0-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnfsidmap2" uniqueId="Ubuntu_12.04-i686-libnfsidmap2-0.25-1ubuntu2" version="0.25-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnih-dbus1" uniqueId="Ubuntu_12.04-i686-libnih-dbus1-1.0.3-4ubuntu9" version="1.0.3-4ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnih1" uniqueId="Ubuntu_12.04-i686-libnih1-1.0.3-4ubuntu9" version="1.0.3-4ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnl-3-200" uniqueId="Ubuntu_12.04-i686-libnl-3-200-3.2.3-2ubuntu2" version="3.2.3-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnl-genl-3-200" uniqueId="Ubuntu_12.04-i686-libnl-genl-3-200-3.2.3-2ubuntu2" version="3.2.3-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libopts25" uniqueId="Ubuntu_12.04-i686-libopts25-1:5.12-0.1ubuntu1" version="1:5.12-0.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libp11-kit0" uniqueId="Ubuntu_12.04-i686-libp11-kit0-0.12-2ubuntu1" version="0.12-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpam-modules" uniqueId="Ubuntu_12.04-i686-libpam-modules-1.1.3-7ubuntu2" version="1.1.3-7ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpam-modules-bin" uniqueId="Ubuntu_12.04-i686-libpam-modules-bin-1.1.3-7ubuntu2" version="1.1.3-7ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpam-runtime" uniqueId="Ubuntu_12.04-i686-libpam-runtime-1.1.3-7ubuntu2" version="1.1.3-7ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpam0g" uniqueId="Ubuntu_12.04-i686-libpam0g-1.1.3-7ubuntu2" version="1.1.3-7ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libparse-debianchangelog-perl" uniqueId="Ubuntu_12.04-i686-libparse-debianchangelog-perl-1.2.0-1ubuntu1" version="1.2.0-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libparted0debian1" uniqueId="Ubuntu_12.04-i686-libparted0debian1-2.3-8ubuntu5" version="2.3-8ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpcap0.8" uniqueId="Ubuntu_12.04-i686-libpcap0.8-1.1.1-10" version="1.1.1-10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpci3" uniqueId="Ubuntu_12.04-i686-libpci3-1:3.1.8-2ubuntu5" version="1:3.1.8-2ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpciaccess0" uniqueId="Ubuntu_12.04-i686-libpciaccess0-0.12.902-1" version="0.12.902-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpcre3" uniqueId="Ubuntu_12.04-i686-libpcre3-8.12-4" version="8.12-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpipeline1" uniqueId="Ubuntu_12.04-i686-libpipeline1-1.2.1-1" version="1.2.1-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libplymouth2" uniqueId="Ubuntu_12.04-i686-libplymouth2-0.8.2-2ubuntu30" version="0.8.2-2ubuntu30" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpng12-0" uniqueId="Ubuntu_12.04-i686-libpng12-0-1.2.46-3ubuntu4" version="1.2.46-3ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpolkit-gobject-1-0" uniqueId="Ubuntu_12.04-i686-libpolkit-gobject-1-0-0.104-1" version="0.104-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpopt0" uniqueId="Ubuntu_12.04-i686-libpopt0-1.16-3ubuntu1" version="1.16-3ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libquadmath0" uniqueId="Ubuntu_12.04-i686-libquadmath0-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libreadline-dev" uniqueId="Ubuntu_12.04-i686-libreadline-dev-6.2-8" version="6.2-8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libreadline6" uniqueId="Ubuntu_12.04-i686-libreadline6-6.2-8" version="6.2-8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libreadline6-dev" uniqueId="Ubuntu_12.04-i686-libreadline6-dev-6.2-8" version="6.2-8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libroken18-heimdal" uniqueId="Ubuntu_12.04-i686-libroken18-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="librtmp0" uniqueId="Ubuntu_12.04-i686-librtmp0-2.4~20110711.gitc28f1bab-1" version="2.4~20110711.gitc28f1bab-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsasl2-2" uniqueId="Ubuntu_12.04-i686-libsasl2-2-2.1.25.dfsg1-3" version="2.1.25.dfsg1-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsasl2-modules" uniqueId="Ubuntu_12.04-i686-libsasl2-modules-2.1.25.dfsg1-3" version="2.1.25.dfsg1-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libselinux1" uniqueId="Ubuntu_12.04-i686-libselinux1-2.1.0-4.1ubuntu1" version="2.1.0-4.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsigc++-2.0-0c2a" uniqueId="Ubuntu_12.04-i686-libsigc++-2.0-0c2a-2.2.10-0ubuntu2" version="2.2.10-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libslang2" uniqueId="Ubuntu_12.04-i686-libslang2-2.2.4-3ubuntu1" version="2.2.4-3ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsqlite3-0" uniqueId="Ubuntu_12.04-i686-libsqlite3-0-3.7.9-2ubuntu1" version="3.7.9-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libss2" uniqueId="Ubuntu_12.04-i686-libss2-1.42-1ubuntu2" version="1.42-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libssl-dev" uniqueId="Ubuntu_12.04-i686-libssl-dev-1.0.1-4ubuntu5.5" version="1.0.1-4ubuntu5.5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libssl-doc" uniqueId="Ubuntu_12.04-i686-libssl-doc-1.0.1-4ubuntu5.5" version="1.0.1-4ubuntu5.5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libssl1.0.0" uniqueId="Ubuntu_12.04-i686-libssl1.0.0-1.0.1-4ubuntu5.5" version="1.0.1-4ubuntu5.5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libstdc++6" uniqueId="Ubuntu_12.04-i686-libstdc++6-4.6.3-1ubuntu5" version="4.6.3-1ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsub-name-perl" uniqueId="Ubuntu_12.04-i686-libsub-name-perl-0.05-1build2" version="0.05-1build2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libswitch-perl" uniqueId="Ubuntu_12.04-i686-libswitch-perl-2.16-2" version="2.16-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtasn1-3" uniqueId="Ubuntu_12.04-i686-libtasn1-3-2.10-1ubuntu1" version="2.10-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtext-charwidth-perl" uniqueId="Ubuntu_12.04-i686-libtext-charwidth-perl-0.04-7build1" version="0.04-7build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtext-iconv-perl" uniqueId="Ubuntu_12.04-i686-libtext-iconv-perl-1.7-5" version="1.7-5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtext-wrapi18n-perl" uniqueId="Ubuntu_12.04-i686-libtext-wrapi18n-perl-0.06-7" version="0.06-7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtimedate-perl" uniqueId="Ubuntu_12.04-i686-libtimedate-perl-1.2000-1" version="1.2000-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtinfo-dev" uniqueId="Ubuntu_12.04-i686-libtinfo-dev-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtinfo5" uniqueId="Ubuntu_12.04-i686-libtinfo5-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtirpc1" uniqueId="Ubuntu_12.04-i686-libtirpc1-0.2.2-5" version="0.2.2-5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libudev0" uniqueId="Ubuntu_12.04-i686-libudev0-175-0ubuntu9" version="175-0ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libusb-0.1-4" uniqueId="Ubuntu_12.04-i686-libusb-0.1-4-2:0.1.12-20" version="2:0.1.12-20" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libusb-1.0-0" uniqueId="Ubuntu_12.04-i686-libusb-1.0-0-2:1.0.9~rc3-2ubuntu1" version="2:1.0.9~rc3-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libuuid1" uniqueId="Ubuntu_12.04-i686-libuuid1-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libwind0-heimdal" uniqueId="Ubuntu_12.04-i686-libwind0-heimdal-1.6~git20120311.dfsg.1-2" version="1.6~git20120311.dfsg.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libwrap0" uniqueId="Ubuntu_12.04-i686-libwrap0-7.6.q-21" version="7.6.q-21" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libx11-6" uniqueId="Ubuntu_12.04-i686-libx11-6-2:1.4.99.1-0ubuntu2" version="2:1.4.99.1-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libx11-data" uniqueId="Ubuntu_12.04-i686-libx11-data-2:1.4.99.1-0ubuntu2" version="2:1.4.99.1-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxapian22" uniqueId="Ubuntu_12.04-i686-libxapian22-1.2.8-1" version="1.2.8-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxau6" uniqueId="Ubuntu_12.04-i686-libxau6-1:1.0.6-4" version="1:1.0.6-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxcb1" uniqueId="Ubuntu_12.04-i686-libxcb1-1.8.1-1" version="1.8.1-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxdmcp6" uniqueId="Ubuntu_12.04-i686-libxdmcp6-1:1.1.0-4" version="1:1.1.0-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxext6" uniqueId="Ubuntu_12.04-i686-libxext6-2:1.3.0-3build1" version="2:1.3.0-3build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxml2" uniqueId="Ubuntu_12.04-i686-libxml2-2.7.8.dfsg-5.1ubuntu4" version="2.7.8.dfsg-5.1ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxmuu1" uniqueId="Ubuntu_12.04-i686-libxmuu1-2:1.1.0-3" version="2:1.1.0-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-firmware" uniqueId="Ubuntu_12.04-i686-linux-firmware-1.79" version="1.79" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-generic-pae" uniqueId="Ubuntu_12.04-i686-linux-generic-pae-3.2.0.23.25" version="3.2.0.23.25" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-image-3.2.0-23-generic-pae" uniqueId="Ubuntu_12.04-i686-linux-image-3.2.0-23-generic-pae-3.2.0-23.36" version="3.2.0-23.36" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-image-generic-pae" uniqueId="Ubuntu_12.04-i686-linux-image-generic-pae-3.2.0.23.25" version="3.2.0.23.25" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-libc-dev" uniqueId="Ubuntu_12.04-i686-linux-libc-dev-3.2.0-30.48" version="3.2.0-30.48" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="locales" uniqueId="Ubuntu_12.04-i686-locales-2.13+git20120306-3" version="2.13+git20120306-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lockfile-progs" uniqueId="Ubuntu_12.04-i686-lockfile-progs-0.1.16" version="0.1.16" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="login" uniqueId="Ubuntu_12.04-i686-login-1:4.1.4.2+svn3283-3ubuntu5" version="1:4.1.4.2+svn3283-3ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="logrotate" uniqueId="Ubuntu_12.04-i686-logrotate-3.7.8-6ubuntu5" version="3.7.8-6ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lsb-base" uniqueId="Ubuntu_12.04-i686-lsb-base-4.0-0ubuntu20" version="4.0-0ubuntu20" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lsb-release" uniqueId="Ubuntu_12.04-i686-lsb-release-4.0-0ubuntu20" version="4.0-0ubuntu20" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lshw" uniqueId="Ubuntu_12.04-i686-lshw-02.15-2" version="02.15-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lsof" uniqueId="Ubuntu_12.04-i686-lsof-4.81.dfsg.1-1build1" version="4.81.dfsg.1-1build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ltrace" uniqueId="Ubuntu_12.04-i686-ltrace-0.5.3-2.1ubuntu2" version="0.5.3-2.1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lvm2" uniqueId="Ubuntu_12.04-i686-lvm2-2.02.66-4ubuntu7" version="2.02.66-4ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="makedev" uniqueId="Ubuntu_12.04-i686-makedev-2.3.1-89ubuntu2" version="2.3.1-89ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="man-db" uniqueId="Ubuntu_12.04-i686-man-db-2.6.1-2" version="2.6.1-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="manpages" uniqueId="Ubuntu_12.04-i686-manpages-3.35-0.1ubuntu1" version="3.35-0.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="manpages-dev" uniqueId="Ubuntu_12.04-i686-manpages-dev-3.35-0.1ubuntu1" version="3.35-0.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mawk" uniqueId="Ubuntu_12.04-i686-mawk-1.3.3-17" version="1.3.3-17" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="memtest86+" uniqueId="Ubuntu_12.04-i686-memtest86+-4.20-1.1ubuntu1" version="4.20-1.1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mime-support" uniqueId="Ubuntu_12.04-i686-mime-support-3.51-1ubuntu1" version="3.51-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mlocate" uniqueId="Ubuntu_12.04-i686-mlocate-0.23.1-1ubuntu2" version="0.23.1-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="module-init-tools" uniqueId="Ubuntu_12.04-i686-module-init-tools-3.16-1ubuntu2" version="3.16-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mount" uniqueId="Ubuntu_12.04-i686-mount-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mountall" uniqueId="Ubuntu_12.04-i686-mountall-2.36" version="2.36" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mtr-tiny" uniqueId="Ubuntu_12.04-i686-mtr-tiny-0.80-1ubuntu1" version="0.80-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="multiarch-support" uniqueId="Ubuntu_12.04-i686-multiarch-support-2.15-0ubuntu10" version="2.15-0ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nano" uniqueId="Ubuntu_12.04-i686-nano-2.2.6-1" version="2.2.6-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses-base" uniqueId="Ubuntu_12.04-i686-ncurses-base-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses-bin" uniqueId="Ubuntu_12.04-i686-ncurses-bin-5.9-4" version="5.9-4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="net-tools" uniqueId="Ubuntu_12.04-i686-net-tools-1.60-24.1ubuntu2" version="1.60-24.1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="netbase" uniqueId="Ubuntu_12.04-i686-netbase-4.47ubuntu1" version="4.47ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="netcat-openbsd" uniqueId="Ubuntu_12.04-i686-netcat-openbsd-1.89-4ubuntu1" version="1.89-4ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nfs-common" uniqueId="Ubuntu_12.04-i686-nfs-common-1:1.2.5-3ubuntu3" version="1:1.2.5-3ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ntfs-3g" uniqueId="Ubuntu_12.04-i686-ntfs-3g-1:2012.1.15AR.1-1ubuntu1" version="1:2012.1.15AR.1-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ntp" uniqueId="Ubuntu_12.04-i686-ntp-1:4.2.6.p3+dfsg-1ubuntu3.1" version="1:4.2.6.p3+dfsg-1ubuntu3.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ntpdate" uniqueId="Ubuntu_12.04-i686-ntpdate-1:4.2.6.p3+dfsg-1ubuntu3" version="1:4.2.6.p3+dfsg-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssh-client" uniqueId="Ubuntu_12.04-i686-openssh-client-1:5.9p1-5ubuntu1" version="1:5.9p1-5ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssh-server" uniqueId="Ubuntu_12.04-i686-openssh-server-1:5.9p1-5ubuntu1" version="1:5.9p1-5ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssl" uniqueId="Ubuntu_12.04-i686-openssl-1.0.1-4ubuntu3" version="1.0.1-4ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="os-prober" uniqueId="Ubuntu_12.04-i686-os-prober-1.51ubuntu3" version="1.51ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="parted" uniqueId="Ubuntu_12.04-i686-parted-2.3-8ubuntu5" version="2.3-8ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="passwd" uniqueId="Ubuntu_12.04-i686-passwd-1:4.1.4.2+svn3283-3ubuntu5" version="1:4.1.4.2+svn3283-3ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="patch" uniqueId="Ubuntu_12.04-i686-patch-2.6.1-3" version="2.6.1-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pciutils" uniqueId="Ubuntu_12.04-i686-pciutils-1:3.1.8-2ubuntu5" version="1:3.1.8-2ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl" uniqueId="Ubuntu_12.04-i686-perl-5.14.2-6ubuntu2" version="5.14.2-6ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-base" uniqueId="Ubuntu_12.04-i686-perl-base-5.14.2-6ubuntu2" version="5.14.2-6ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-modules" uniqueId="Ubuntu_12.04-i686-perl-modules-5.14.2-6ubuntu2" version="5.14.2-6ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="plymouth" uniqueId="Ubuntu_12.04-i686-plymouth-0.8.2-2ubuntu30" version="0.8.2-2ubuntu30" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="plymouth-theme-ubuntu-text" uniqueId="Ubuntu_12.04-i686-plymouth-theme-ubuntu-text-0.8.2-2ubuntu30" version="0.8.2-2ubuntu30" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="popularity-contest" uniqueId="Ubuntu_12.04-i686-popularity-contest-1.53ubuntu1" version="1.53ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="powermgmt-base" uniqueId="Ubuntu_12.04-i686-powermgmt-base-1.31" version="1.31" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ppp" uniqueId="Ubuntu_12.04-i686-ppp-2.4.5-5ubuntu1" version="2.4.5-5ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pppconfig" uniqueId="Ubuntu_12.04-i686-pppconfig-2.3.18+nmu3ubuntu1" version="2.3.18+nmu3ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pppoeconf" uniqueId="Ubuntu_12.04-i686-pppoeconf-1.20ubuntu1" version="1.20ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="procps" uniqueId="Ubuntu_12.04-i686-procps-1:3.2.8-11ubuntu6" version="1:3.2.8-11ubuntu6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="psmisc" uniqueId="Ubuntu_12.04-i686-psmisc-22.15-2ubuntu1" version="22.15-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python" uniqueId="Ubuntu_12.04-i686-python-2.7.3-0ubuntu2" version="2.7.3-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-apt" uniqueId="Ubuntu_12.04-i686-python-apt-0.8.3ubuntu7" version="0.8.3ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-apt-common" uniqueId="Ubuntu_12.04-i686-python-apt-common-0.8.3ubuntu7" version="0.8.3ubuntu7" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-chardet" uniqueId="Ubuntu_12.04-i686-python-chardet-2.0.1-2build1" version="2.0.1-2build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-configobj" uniqueId="Ubuntu_12.04-i686-python-configobj-4.7.2+ds-3build1" version="4.7.2+ds-3build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-dbus" uniqueId="Ubuntu_12.04-i686-python-dbus-1.0.0-1ubuntu1" version="1.0.0-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-dbus-dev" uniqueId="Ubuntu_12.04-i686-python-dbus-dev-1.0.0-1ubuntu1" version="1.0.0-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-debian" uniqueId="Ubuntu_12.04-i686-python-debian-0.1.21ubuntu1" version="0.1.21ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-decorator" uniqueId="Ubuntu_12.04-i686-python-decorator-3.3.2-1" version="3.3.2-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-gdbm" uniqueId="Ubuntu_12.04-i686-python-gdbm-2.7.3-1ubuntu1" version="2.7.3-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-gi" uniqueId="Ubuntu_12.04-i686-python-gi-3.2.0-3" version="3.2.0-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-gnupginterface" uniqueId="Ubuntu_12.04-i686-python-gnupginterface-0.3.2-9.1ubuntu3" version="0.3.2-9.1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-minimal" uniqueId="Ubuntu_12.04-i686-python-minimal-2.7.3-0ubuntu2" version="2.7.3-0ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-pexpect" uniqueId="Ubuntu_12.04-i686-python-pexpect-2.3-1ubuntu2" version="2.3-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-simplegeneric" uniqueId="Ubuntu_12.04-i686-python-simplegeneric-0.7-1build1" version="0.7-1build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-support" uniqueId="Ubuntu_12.04-i686-python-support-1.0.14ubuntu2" version="1.0.14ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-xapian" uniqueId="Ubuntu_12.04-i686-python-xapian-1.2.8-1" version="1.2.8-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python2.7" uniqueId="Ubuntu_12.04-i686-python2.7-2.7.3-0ubuntu3" version="2.7.3-0ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python2.7-minimal" uniqueId="Ubuntu_12.04-i686-python2.7-minimal-2.7.3-0ubuntu3" version="2.7.3-0ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="readline-common" uniqueId="Ubuntu_12.04-i686-readline-common-6.2-8" version="6.2-8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="resolvconf" uniqueId="Ubuntu_12.04-i686-resolvconf-1.63ubuntu11" version="1.63ubuntu11" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpcbind" uniqueId="Ubuntu_12.04-i686-rpcbind-0.2.0-7ubuntu1.1" version="0.2.0-7ubuntu1.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rsync" uniqueId="Ubuntu_12.04-i686-rsync-3.0.9-1ubuntu1" version="3.0.9-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rsyslog" uniqueId="Ubuntu_12.04-i686-rsyslog-5.8.6-1ubuntu8" version="5.8.6-1ubuntu8" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sed" uniqueId="Ubuntu_12.04-i686-sed-4.2.1-9" version="4.2.1-9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sensible-utils" uniqueId="Ubuntu_12.04-i686-sensible-utils-0.0.6ubuntu2" version="0.0.6ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sgml-base" uniqueId="Ubuntu_12.04-i686-sgml-base-1.26+nmu1ubuntu1" version="1.26+nmu1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ssh-import-id" uniqueId="Ubuntu_12.04-i686-ssh-import-id-2.10-0ubuntu1" version="2.10-0ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="strace" uniqueId="Ubuntu_12.04-i686-strace-4.5.20-2.3ubuntu1" version="4.5.20-2.3ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sudo" uniqueId="Ubuntu_12.04-i686-sudo-1.8.3p1-1ubuntu3" version="1.8.3p1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sysv-rc" uniqueId="Ubuntu_12.04-i686-sysv-rc-2.88dsf-13.10ubuntu11" version="2.88dsf-13.10ubuntu11" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sysvinit-utils" uniqueId="Ubuntu_12.04-i686-sysvinit-utils-2.88dsf-13.10ubuntu11" version="2.88dsf-13.10ubuntu11" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tar" uniqueId="Ubuntu_12.04-i686-tar-1.26-4ubuntu1" version="1.26-4ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tasksel" uniqueId="Ubuntu_12.04-i686-tasksel-2.88ubuntu9" version="2.88ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tasksel-data" uniqueId="Ubuntu_12.04-i686-tasksel-data-2.88ubuntu9" version="2.88ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tcpd" uniqueId="Ubuntu_12.04-i686-tcpd-7.6.q-21" version="7.6.q-21" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tcpdump" uniqueId="Ubuntu_12.04-i686-tcpdump-4.2.1-1ubuntu2" version="4.2.1-1ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="telnet" uniqueId="Ubuntu_12.04-i686-telnet-0.17-36build1" version="0.17-36build1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="time" uniqueId="Ubuntu_12.04-i686-time-1.7-23.1" version="1.7-23.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tzdata" uniqueId="Ubuntu_12.04-i686-tzdata-2012b-1" version="2012b-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ubuntu-keyring" uniqueId="Ubuntu_12.04-i686-ubuntu-keyring-2011.11.21" version="2011.11.21" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ubuntu-minimal" uniqueId="Ubuntu_12.04-i686-ubuntu-minimal-1.267" version="1.267" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ubuntu-standard" uniqueId="Ubuntu_12.04-i686-ubuntu-standard-1.267" version="1.267" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ucf" uniqueId="Ubuntu_12.04-i686-ucf-3.0025+nmu2ubuntu1" version="3.0025+nmu2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="udev" uniqueId="Ubuntu_12.04-i686-udev-175-0ubuntu9" version="175-0ubuntu9" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ufw" uniqueId="Ubuntu_12.04-i686-ufw-0.31.1-1" version="0.31.1-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="update-manager-core" uniqueId="Ubuntu_12.04-i686-update-manager-core-1:0.156.14" version="1:0.156.14" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="upstart" uniqueId="Ubuntu_12.04-i686-upstart-1.5-0ubuntu5" version="1.5-0ubuntu5" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ureadahead" uniqueId="Ubuntu_12.04-i686-ureadahead-0.100.0-12" version="0.100.0-12" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="usbutils" uniqueId="Ubuntu_12.04-i686-usbutils-1:005-1" version="1:005-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="util-linux" uniqueId="Ubuntu_12.04-i686-util-linux-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="uuid-runtime" uniqueId="Ubuntu_12.04-i686-uuid-runtime-2.20.1-1ubuntu3" version="2.20.1-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="vim-common" uniqueId="Ubuntu_12.04-i686-vim-common-2:7.3.429-2ubuntu2" version="2:7.3.429-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="vim-tiny" uniqueId="Ubuntu_12.04-i686-vim-tiny-2:7.3.429-2ubuntu2" version="2:7.3.429-2ubuntu2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="watershed" uniqueId="Ubuntu_12.04-i686-watershed-6" version="6" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="wget" uniqueId="Ubuntu_12.04-i686-wget-1.13.4-2ubuntu1" version="1.13.4-2ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="whiptail" uniqueId="Ubuntu_12.04-i686-whiptail-0.52.11-2ubuntu10" version="0.52.11-2ubuntu10" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="wireless-regdb" uniqueId="Ubuntu_12.04-i686-wireless-regdb-2011.04.28-1ubuntu3" version="2011.04.28-1ubuntu3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xauth" uniqueId="Ubuntu_12.04-i686-xauth-1:1.0.6-1" version="1:1.0.6-1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xkb-data" uniqueId="Ubuntu_12.04-i686-xkb-data-2.5-1ubuntu1" version="2.5-1ubuntu1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xml-core" uniqueId="Ubuntu_12.04-i686-xml-core-0.13" version="0.13" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xz-lzma" uniqueId="Ubuntu_12.04-i686-xz-lzma-5.1.1alpha+20110809-3" version="5.1.1alpha+20110809-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xz-utils" uniqueId="Ubuntu_12.04-i686-xz-utils-5.1.1alpha+20110809-3" version="5.1.1alpha+20110809-3" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="zlib1g" uniqueId="Ubuntu_12.04-i686-zlib1g-1:1.2.3.4.dfsg-3ubuntu4" version="1:1.2.3.4.dfsg-3ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="zlib1g-dev" uniqueId="Ubuntu_12.04-i686-zlib1g-dev-1:1.2.3.4.dfsg-3ubuntu4" version="1:1.2.3.4.dfsg-3ubuntu4" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>

--- a/tests/dumps/swid_tags/rpm-swid-full.txt
+++ b/tests/dumps/swid_tags/rpm-swid-full.txt
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="avahi-libs" uniqueId="fedora_19-i686-avahi-libs-0.6.31-11.fc19" version="0.6.31-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libavahi-client.so.3"/>
     <File location="/usr/lib" name="libavahi-client.so.3.2.9"/>
@@ -11,13 +11,13 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="filesystem" uniqueId="fedora_19-i686-filesystem-3.2-10.fc19" version="3.2-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="avahi-autoipd" uniqueId="fedora_19-i686-avahi-autoipd-0.6.31-11.fc19" version="0.6.31-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/avahi" name="avahi-autoipd.action"/>
     <File location="/usr/sbin" name="avahi-autoipd"/>
@@ -28,7 +28,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-firmware" uniqueId="fedora_19-i686-linux-firmware-20130418-0.1.gitb584174.fc19" version="20130418-0.1.gitb584174.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/firmware/3com" name="3C359.bin"/>
     <File location="/lib/firmware/3com" name="typhoon.bin"/>
@@ -585,7 +585,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="quota" uniqueId="fedora_19-i686-quota-4.01-6.fc19" version="4.01-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="quotacheck"/>
     <File location="/sbin" name="quotaoff"/>
@@ -620,7 +620,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="quota-nls" uniqueId="fedora_19-i686-quota-nls-4.01-6.fc19" version="4.01-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/quota-nls-4.01" name="Changelog"/>
     <File location="/usr/share/locale/cs/LC_MESSAGES" name="quota.mo"/>
@@ -632,7 +632,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nfs-utils" uniqueId="fedora_19-i686-nfs-utils-1.2.8-2.0.fc19" version="1.2.8-2.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="nfsmount.conf"/>
     <File location="/etc/request-key.d" name="id_resolver.conf"/>
@@ -724,7 +724,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hwdata" uniqueId="fedora_19-i686-hwdata-0.247-1.fc19" version="0.247-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/modprobe.d" name="dist-blacklist.conf"/>
     <File location="/usr/share/doc/hwdata-0.247" name="COPYING"/>
@@ -738,7 +738,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sendmail" uniqueId="fedora_19-i686-sendmail-8.14.7-1.fc19" version="8.14.7-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/NetworkManager/dispatcher.d" name="10-sendmail"/>
     <File location="/etc/mail" name="Makefile"/>
@@ -809,7 +809,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bind-license" uniqueId="fedora_19-i686-bind-license-9.9.3-3.P1.fc19" version="9.9.3-3.P1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/bind-license-9.9.3" name="COPYRIGHT"/>
   </Payload>
@@ -817,7 +817,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kernel-PAE" uniqueId="fedora_19-i686-kernel-PAE-3.9.5-301.fc19" version="3.9.5-301.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/boot" name=".vmlinuz-3.9.5-301.fc19.i686.PAE.hmac"/>
     <File location="/boot" name="System.map-3.9.5-301.fc19.i686.PAE"/>
@@ -3161,7 +3161,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kernel-headers" uniqueId="fedora_19-i686-kernel-headers-3.9.5-301.fc19" version="3.9.5-301.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include/asm-generic" name="auxvec.h"/>
     <File location="/usr/include/asm-generic" name="bitsperlong.h"/>
@@ -3872,7 +3872,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="authconfig" uniqueId="fedora_19-i686-authconfig-6.2.6-3.fc19.1" version="6.2.6-3.fc19.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pam.d" name="fingerprint-auth-ac"/>
     <File location="/etc/pam.d" name="password-auth-ac"/>
@@ -3992,13 +3992,13 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rootfiles" uniqueId="fedora_19-i686-rootfiles-8.1-10.fc19" version="8.1-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lvm2" uniqueId="fedora_19-i686-lvm2-2.02.98-9.fc19" version="2.02.98-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/lvm" name="lvm.conf"/>
     <File location="/usr/lib/systemd/system-generators" name="lvm2-activation-generator"/>
@@ -4120,7 +4120,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss-softokn-freebl" uniqueId="fedora_19-i686-nss-softokn-freebl-3.14.3-1.fc19" version="3.14.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libfreebl3.chk"/>
     <File location="/usr/lib" name="libfreebl3.so"/>
@@ -4129,7 +4129,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssh-clients" uniqueId="fedora_19-i686-openssh-clients-6.2p2-3.fc19" version="6.2p2-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/ssh" name="ssh_config"/>
     <File location="/usr/bin" name="scp"/>
@@ -4157,7 +4157,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libstdc++" uniqueId="fedora_19-i686-libstdc++-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libstdc++.so.6"/>
     <File location="/usr/lib" name="libstdc++.so.6.0.18"/>
@@ -4178,7 +4178,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="audit" uniqueId="fedora_19-i686-audit-2.3.1-2.fc19" version="2.3.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="audispd"/>
     <File location="/sbin" name="auditctl"/>
@@ -4220,7 +4220,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bash" uniqueId="fedora_19-i686-bash-4.2.45-1.fc19" version="4.2.45-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/skel" name=".bash_logout"/>
     <File location="/etc/skel" name=".bash_profile"/>
@@ -4335,7 +4335,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="parted" uniqueId="fedora_19-i686-parted-3.1-12.fc19" version="3.1-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libparted-fs-resize.so"/>
     <File location="/lib" name="libparted-fs-resize.so.0"/>
@@ -4389,7 +4389,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libattr" uniqueId="fedora_19-i686-libattr-2.4.46-10.fc19" version="2.4.46-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libattr.so.1"/>
     <File location="/usr/lib" name="libattr.so.1.1.0"/>
@@ -4398,7 +4398,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sudo" uniqueId="fedora_19-i686-sudo-1.8.6p7-1.fc19" version="1.8.6p7-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pam.d" name="sudo"/>
     <File location="/etc/pam.d" name="sudo-i"/>
@@ -4470,7 +4470,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pcre" uniqueId="fedora_19-i686-pcre-8.32-7.fc19" version="8.32-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libpcre.so.1"/>
     <File location="/usr/lib" name="libpcre.so.1.2.0"/>
@@ -4493,7 +4493,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="man-db" uniqueId="fedora_19-i686-man-db-2.6.3-6.fc19" version="2.6.3-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/cron.daily" name="man-db.cron"/>
     <File location="/etc" name="man_db.conf"/>
@@ -4604,7 +4604,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="zlib" uniqueId="fedora_19-i686-zlib-1.2.7-10.fc19" version="1.2.7-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libz.so.1"/>
     <File location="/usr/lib" name="libz.so.1.2.7"/>
@@ -4616,7 +4616,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bzip2" uniqueId="fedora_19-i686-bzip2-1.0.6-8.fc19" version="1.0.6-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="bunzip2"/>
     <File location="/usr/bin" name="bzcat"/>
@@ -4644,7 +4644,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcom_err" uniqueId="fedora_19-i686-libcom_err-1.42.7-2.fc19" version="1.42.7-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libcom_err.so.2"/>
     <File location="/usr/lib" name="libcom_err.so.2.1"/>
@@ -4654,13 +4654,13 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gpg-pubkey" uniqueId="fedora_19-i686-gpg-pubkey-fb4b18e6-50b96bfd" version="fb4b18e6-50b96bfd" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdb" uniqueId="fedora_19-i686-libdb-5.3.21-11.fc19" version="5.3.21-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libdb-5.3.so"/>
     <File location="/usr/lib" name="libdb-5.so"/>
@@ -4671,7 +4671,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-pip" uniqueId="fedora_19-i686-python-pip-1.3.1-4.fc19" version="1.3.1-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="pip"/>
     <File location="/usr/bin" name="pip-python"/>
@@ -4802,7 +4802,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="popt" uniqueId="fedora_19-i686-popt-1.13-14.fc19" version="1.13-14.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libpopt.so.0"/>
     <File location="/lib" name="libpopt.so.0.0.0"/>
@@ -4839,7 +4839,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-TermReadKey" uniqueId="fedora_19-i686-perl-TermReadKey-2.30-18.fc19" version="2.30-18.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/vendor_perl/Term" name="ReadKey.pm"/>
     <File location="/usr/lib/perl5/vendor_perl/auto/Term/ReadKey" name="ReadKey.so"/>
@@ -4851,7 +4851,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xz-libs" uniqueId="fedora_19-i686-xz-libs-5.1.2-4alpha.fc19" version="5.1.2-4alpha.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="liblzma.so.5"/>
     <File location="/usr/lib" name="liblzma.so.5.0.99"/>
@@ -4864,7 +4864,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgnome-keyring" uniqueId="fedora_19-i686-libgnome-keyring-3.8.0-1.fc19" version="3.8.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/girepository-1.0" name="GnomeKeyring-1.0.typelib"/>
     <File location="/usr/lib" name="libgnome-keyring.so.0"/>
@@ -4949,7 +4949,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sed" uniqueId="fedora_19-i686-sed-4.2.2-2.fc19" version="4.2.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="sed"/>
     <File location="/usr/share/doc/sed-4.2.2" name="AUTHORS"/>
@@ -5005,7 +5005,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Git" uniqueId="fedora_19-i686-perl-Git-1.8.3.1-1.fc19" version="1.8.3.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man3" name="Git.3pm.gz"/>
     <File location="/usr/share/man/man3" name="Git::I18N.3pm.gz"/>
@@ -5017,7 +5017,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libuuid" uniqueId="fedora_19-i686-libuuid-2.23.1-3.fc19" version="2.23.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libuuid.so.1"/>
     <File location="/usr/lib" name="libuuid.so.1.3.0"/>
@@ -5027,7 +5027,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-kitchen" uniqueId="fedora_19-i686-python-kitchen-1.1.1-4.fc19" version="1.1.1-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages/kitchen-1.1.1-py2.7.egg-info" name="PKG-INFO"/>
     <File location="/usr/lib/python2.7/site-packages/kitchen-1.1.1-py2.7.egg-info" name="SOURCES.txt"/>
@@ -5185,7 +5185,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grep" uniqueId="fedora_19-i686-grep-2.14-3.fc19" version="2.14-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="egrep"/>
     <File location="/bin" name="fgrep"/>
@@ -5253,7 +5253,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tcp_wrappers-libs" uniqueId="fedora_19-i686-tcp_wrappers-libs-7.6-73.fc19" version="7.6-73.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libwrap.so.0"/>
     <File location="/usr/lib" name="libwrap.so.0.7.6"/>
@@ -5275,7 +5275,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gmp" uniqueId="fedora_19-i686-gmp-5.1.1-2.fc19" version="5.1.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libgmp.so.10"/>
     <File location="/usr/lib" name="libgmp.so.10.1.1"/>
@@ -5294,7 +5294,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgcrypt" uniqueId="fedora_19-i686-libgcrypt-1.5.2-1.fc19" version="1.5.2-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name=".libgcrypt.so.11.hmac"/>
     <File location="/lib" name="libgcrypt.so.11"/>
@@ -5308,7 +5308,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="expat" uniqueId="fedora_19-i686-expat-2.1.0-5.fc19" version="2.1.0-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="xmlwf"/>
     <File location="/usr/lib" name="libexpat.so.1"/>
@@ -5321,7 +5321,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gawk" uniqueId="fedora_19-i686-gawk-4.0.2-2.fc19" version="4.0.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="awk"/>
     <File location="/usr/bin" name="dgawk"/>
@@ -5381,7 +5381,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sqlite" uniqueId="fedora_19-i686-sqlite-3.7.17-1.fc19" version="3.7.17-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="sqlite3"/>
     <File location="/usr/lib" name="libsqlite3.so.0"/>
@@ -5393,7 +5393,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxml2" uniqueId="fedora_19-i686-libxml2-2.9.1-1.fc19" version="2.9.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="xmlcatalog"/>
     <File location="/usr/bin" name="xmllint"/>
@@ -5412,7 +5412,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pkgconfig" uniqueId="fedora_19-i686-pkgconfig-0.27.1-1.fc19" version="0.27.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="pkg-config"/>
     <File location="/usr/share/aclocal" name="pkg.m4"/>
@@ -5427,7 +5427,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="shared-mime-info" uniqueId="fedora_19-i686-shared-mime-info-1.1-4.fc19" version="1.1-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="update-mime-database"/>
     <File location="/usr/share/applications" name="defaults.list"/>
@@ -6133,7 +6133,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dbus-glib" uniqueId="fedora_19-i686-dbus-glib-0.100-4.fc19" version="0.100-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="dbus-binding-tool"/>
     <File location="/usr/lib" name="libdbus-glib-1.so.2"/>
@@ -6145,7 +6145,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cyrus-sasl-lib" uniqueId="fedora_19-i686-cyrus-sasl-lib-2.1.26-8.fc19" version="2.1.26-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libsasl2.so.3"/>
     <File location="/usr/lib" name="libsasl2.so.3.0.0"/>
@@ -6181,7 +6181,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cpio" uniqueId="fedora_19-i686-cpio-2.11-20.fc19" version="2.11-20.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="cpio"/>
     <File location="/usr/share/doc/cpio-2.11" name="AUTHORS"/>
@@ -6219,7 +6219,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iptables" uniqueId="fedora_19-i686-iptables-1.4.18-1.fc19" version="1.4.18-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/sysconfig" name="ip6tables-config"/>
     <File location="/etc/sysconfig" name="iptables-config"/>
@@ -6361,7 +6361,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libestr" uniqueId="fedora_19-i686-libestr-0.1.5-1.fc19" version="0.1.5-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libestr.so.0"/>
     <File location="/usr/lib" name="libestr.so.0.0.0"/>
@@ -6374,7 +6374,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Encode" uniqueId="fedora_19-i686-perl-Encode-2.51-1.fc19" version="2.51-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="piconv"/>
     <File location="/usr/lib/perl5/vendor_perl" name="Encode.pm"/>
@@ -6440,7 +6440,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-libs" uniqueId="fedora_19-i686-perl-libs-5.16.3-264.fc19" version="5.16.3-264.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/CORE" name="libperl.so"/>
   </Payload>
@@ -6448,7 +6448,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-threads" uniqueId="fedora_19-i686-perl-threads-1.87-1.fc19" version="1.87-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/vendor_perl/auto/threads" name="threads.so"/>
     <File location="/usr/lib/perl5/vendor_perl" name="threads.pm"/>
@@ -6460,7 +6460,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-threads-shared" uniqueId="fedora_19-i686-perl-threads-shared-1.43-2.fc19" version="1.43-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/vendor_perl/auto/threads/shared" name="shared.so"/>
     <File location="/usr/lib/perl5/vendor_perl/threads" name="shared.pm"/>
@@ -6472,7 +6472,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Carp" uniqueId="fedora_19-i686-perl-Carp-1.26-243.fc19" version="1.26-243.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/perl-Carp-1.26" name="Changes"/>
     <File location="/usr/share/doc/perl-Carp-1.26" name="README"/>
@@ -6484,7 +6484,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Filter" uniqueId="fedora_19-i686-perl-Filter-1.49-1.fc19" version="1.49-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/vendor_perl/Filter/Util" name="Call.pm"/>
     <File location="/usr/lib/perl5/vendor_perl/Filter/Util" name="Exec.pm"/>
@@ -6529,7 +6529,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl" uniqueId="fedora_19-i686-perl-5.16.3-264.fc19" version="5.16.3-264.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="a2p"/>
     <File location="/usr/bin" name="c2ph"/>
@@ -8448,7 +8448,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="p11-kit" uniqueId="fedora_19-i686-p11-kit-0.18.3-1.fc19" version="0.18.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="p11-kit"/>
     <File location="/usr/lib" name="libp11-kit.so.0"/>
@@ -8466,7 +8466,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="file" uniqueId="fedora_19-i686-file-5.11-9.fc19" version="5.11-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="magic"/>
     <File location="/usr/bin" name="file"/>
@@ -8479,7 +8479,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcroco" uniqueId="fedora_19-i686-libcroco-0.6.8-2.fc19" version="0.6.8-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="csslint-0.6"/>
     <File location="/usr/lib" name="libcroco-0.6.so.3"/>
@@ -8494,7 +8494,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="groff-base" uniqueId="fedora_19-i686-groff-base-1.22.2-2.fc19" version="1.22.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/groff/site-tmac" name="man.local"/>
     <File location="/etc/groff/site-tmac" name="mdoc.local"/>
@@ -8685,7 +8685,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kmod" uniqueId="fedora_19-i686-kmod-13-2.fc19" version="13-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="kmod"/>
     <File location="/usr/sbin" name="depmod"/>
@@ -8715,7 +8715,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="which" uniqueId="fedora_19-i686-which-2.20-5.fc19" version="2.20-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/profile.d" name="which2.csh"/>
     <File location="/etc/profile.d" name="which2.sh"/>
@@ -8732,7 +8732,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libverto" uniqueId="fedora_19-i686-libverto-0.2.5-2.fc19" version="0.2.5-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libverto.so.1"/>
     <File location="/usr/lib" name="libverto.so.1.0.0"/>
@@ -8746,7 +8746,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtirpc" uniqueId="fedora_19-i686-libtirpc-0.2.3-2.fc19" version="0.2.3-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="netconfig"/>
     <File location="/lib" name="libtirpc.so.1"/>
@@ -8760,7 +8760,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hostname" uniqueId="fedora_19-i686-hostname-3.12-4.fc19" version="3.12-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="dnsdomainname"/>
     <File location="/bin" name="domainname"/>
@@ -8778,7 +8778,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="slang" uniqueId="fedora_19-i686-slang-2.2.4-8.fc19" version="2.2.4-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libslang.so.2"/>
     <File location="/usr/lib" name="libslang.so.2.2.4"/>
@@ -8794,7 +8794,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses-devel" uniqueId="fedora_19-i686-ncurses-devel-5.9-11.20130511.fc19" version="5.9-11.20130511.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="ncurses5-config"/>
     <File location="/usr/bin" name="ncursesw5-config"/>
@@ -9843,7 +9843,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="zlib-devel" uniqueId="fedora_19-i686-zlib-devel-1.2.7-10.fc19" version="1.2.7-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include" name="zconf.h"/>
     <File location="/usr/include" name="zlib.h"/>
@@ -9858,7 +9858,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libselinux-devel" uniqueId="fedora_19-i686-libselinux-devel-2.1.13-15.fc19" version="2.1.13-15.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include/selinux" name="av_permissions.h"/>
     <File location="/usr/include/selinux" name="avc.h"/>
@@ -10065,7 +10065,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="glibc-headers" uniqueId="fedora_19-i686-glibc-headers-2.17-4.fc19" version="2.17-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include" name="_G_config.h"/>
     <File location="/usr/include" name="a.out.h"/>
@@ -10486,7 +10486,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="krb5-devel" uniqueId="fedora_19-i686-krb5-devel-1.11.3-1.fc19" version="1.11.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="gss-client"/>
     <File location="/usr/bin" name="krb5-config"/>
@@ -10561,7 +10561,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gettext-libs" uniqueId="fedora_19-i686-gettext-libs-0.18.2.1-1.fc19" version="0.18.2.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libasprintf.so.0"/>
     <File location="/usr/lib" name="libasprintf.so.0.0.0"/>
@@ -10574,7 +10574,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cpp" uniqueId="fedora_19-i686-cpp-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="cpp"/>
     <File location="/usr/lib" name="cpp"/>
@@ -10607,7 +10607,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="p11-kit-trust" uniqueId="fedora_19-i686-p11-kit-trust-0.18.3-1.fc19" version="0.18.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/p11-kit" name="p11-kit-extract-trust"/>
     <File location="/usr/lib/pkcs11" name="p11-kit-trust.so"/>
@@ -10617,7 +10617,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssl-libs" uniqueId="fedora_19-i686-openssl-libs-1.0.1e-4.fc19" version="1.0.1e-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pki/tls" name="openssl.cnf"/>
     <File location="/usr/lib" name=".libcrypto.so.1.0.1e.hmac"/>
@@ -10645,7 +10645,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libevent" uniqueId="fedora_19-i686-libevent-2.0.18-3.fc19" version="2.0.18-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libevent-2.0.so.5"/>
     <File location="/usr/lib" name="libevent-2.0.so.5.1.6"/>
@@ -10663,7 +10663,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="fipscheck-lib" uniqueId="fedora_19-i686-fipscheck-lib-1.3.1-3.fc19" version="1.3.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/fipscheck" name="libfipscheck.so.1.1.0.hmac"/>
     <File location="/usr/lib/fipscheck" name="libfipscheck.so.1.hmac"/>
@@ -10674,7 +10674,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gobject-introspection" uniqueId="fedora_19-i686-gobject-introspection-1.36.0-1.fc19" version="1.36.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/girepository-1.0" name="DBus-1.0.typelib"/>
     <File location="/usr/lib/girepository-1.0" name="DBusGLib-1.0.typelib"/>
@@ -10700,7 +10700,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hesiod" uniqueId="fedora_19-i686-hesiod-3.2.1-1.fc19" version="3.2.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="hesinfo"/>
     <File location="/usr/lib" name="libhesiod.so.0"/>
@@ -10715,7 +10715,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="keyutils" uniqueId="fedora_19-i686-keyutils-1.5.5-4.fc19" version="1.5.5-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="keyctl"/>
     <File location="/etc" name="request-key.conf"/>
@@ -10733,7 +10733,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gnutls" uniqueId="fedora_19-i686-gnutls-3.1.11-1.fc19" version="3.1.11-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libgnutls-xssl.so.0"/>
     <File location="/usr/lib" name="libgnutls-xssl.so.0.0.0"/>
@@ -10764,7 +10764,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tcp_wrappers" uniqueId="fedora_19-i686-tcp_wrappers-7.6-73.fc19" version="7.6-73.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="safe_finger"/>
     <File location="/usr/sbin" name="tcpd"/>
@@ -10788,7 +10788,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xz" uniqueId="fedora_19-i686-xz-5.1.2-4alpha.fc19" version="5.1.2-4alpha.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="unxz"/>
     <File location="/usr/bin" name="xz"/>
@@ -10827,7 +10827,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="acl" uniqueId="fedora_19-i686-acl-2.2.51-9.fc19" version="2.2.51-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="chacl"/>
     <File location="/usr/bin" name="getfacl"/>
@@ -10852,7 +10852,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdb-utils" uniqueId="fedora_19-i686-libdb-utils-5.3.21-11.fc19" version="5.3.21-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="db_archive"/>
     <File location="/usr/bin" name="db_checkpoint"/>
@@ -10874,7 +10874,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libatomic" uniqueId="fedora_19-i686-libatomic-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libatomic.so.1"/>
     <File location="/usr/lib" name="libatomic.so.1.0.0"/>
@@ -10883,7 +10883,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libasan" uniqueId="fedora_19-i686-libasan-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libasan.so.0"/>
     <File location="/usr/lib" name="libasan.so.0.0.0"/>
@@ -10892,7 +10892,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libselinux-utils" uniqueId="fedora_19-i686-libselinux-utils-2.1.13-15.fc19" version="2.1.13-15.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="avcstat"/>
     <File location="/usr/sbin" name="getenforce"/>
@@ -10945,7 +10945,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="procps-ng" uniqueId="fedora_19-i686-procps-ng-3.3.7-3.fc19" version="3.3.7-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="free"/>
     <File location="/usr/bin" name="pgrep"/>
@@ -10992,7 +10992,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pth" uniqueId="fedora_19-i686-pth-2.0.7-19.fc19" version="2.0.7-19.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libpth.so.20"/>
     <File location="/usr/lib" name="libpth.so.20.0.27"/>
@@ -11013,7 +11013,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-atm-libs" uniqueId="fedora_19-i686-linux-atm-libs-2.5.1-7.fc19" version="2.5.1-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libatm.so.1"/>
     <File location="/usr/lib" name="libatm.so.1.0.0"/>
@@ -11022,7 +11022,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpciaccess" uniqueId="fedora_19-i686-libpciaccess-0.13.1-3.fc19" version="0.13.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libpciaccess.so.0"/>
     <File location="/usr/lib" name="libpciaccess.so.0.11.1"/>
@@ -11033,7 +11033,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="qrencode-libs" uniqueId="fedora_19-i686-qrencode-libs-3.4.1-1.fc19" version="3.4.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libqrencode.so.3"/>
     <File location="/usr/lib" name="libqrencode.so.3.4.1"/>
@@ -11047,7 +11047,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hardlink" uniqueId="fedora_19-i686-hardlink-1.0-17.fc19" version="1.0-17.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="hardlink"/>
     <File location="/usr/share/man/man1" name="hardlink.1.gz"/>
@@ -11056,7 +11056,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-libs" uniqueId="fedora_19-i686-python-libs-2.7.5-1.fc19" version="2.7.5-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include/python2.7" name="pyconfig-32.h"/>
     <File location="/usr/lib" name="libpython2.7.so.1.0"/>
@@ -13136,7 +13136,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss-tools" uniqueId="fedora_19-i686-nss-tools-3.14.3-13.0.fc19" version="3.14.3-13.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="certutil"/>
     <File location="/usr/bin" name="cmsutil"/>
@@ -13162,7 +13162,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="curl" uniqueId="fedora_19-i686-curl-7.29.0-6.fc19" version="7.29.0-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="curl"/>
     <File location="/usr/share/doc/curl-7.29.0" name="BUGS"/>
@@ -13181,7 +13181,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gzip" uniqueId="fedora_19-i686-gzip-1.5-4.fc19" version="1.5-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="gunzip"/>
     <File location="/usr/bin" name="gzexe"/>
@@ -13219,7 +13219,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cracklib-dicts" uniqueId="fedora_19-i686-cracklib-dicts-2.8.22-3.fc19" version="2.8.22-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="cracklib_dict.hwm"/>
     <File location="/usr/lib" name="cracklib_dict.pwd"/>
@@ -13237,7 +13237,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpm-libs" uniqueId="fedora_19-i686-rpm-libs-4.11.0.1-2.fc19" version="4.11.0.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="librpm.so.3"/>
     <File location="/usr/lib" name="librpm.so.3.1.0"/>
@@ -13248,7 +13248,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cryptsetup-libs" uniqueId="fedora_19-i686-cryptsetup-libs-1.6.1-1.fc19" version="1.6.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/fipscheck" name="libcryptsetup.so.4.5.0.hmac"/>
     <File location="/usr/lib/fipscheck" name="libcryptsetup.so.4.hmac"/>
@@ -13272,7 +13272,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmount" uniqueId="fedora_19-i686-libmount-2.23.1-3.fc19" version="2.23.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libmount.so.1"/>
     <File location="/usr/lib" name="libmount.so.1.1.0"/>
@@ -13282,7 +13282,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libuser" uniqueId="fedora_19-i686-libuser-0.59-1.fc19" version="0.59-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="libuser.conf"/>
     <File location="/usr/bin" name="lchfn"/>
@@ -13385,7 +13385,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss" uniqueId="fedora_19-i686-nss-3.14.3-13.0.fc19" version="3.14.3-13.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pki/nssdb" name="cert8.db"/>
     <File location="/etc/pki/nssdb" name="key3.db"/>
@@ -13401,7 +13401,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pam" uniqueId="fedora_19-i686-pam-1.1.6-11.fc19.1" version="1.1.6-11.fc19.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pam.d" name="config-util"/>
     <File location="/etc/pam.d" name="fingerprint-auth"/>
@@ -13718,7 +13718,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libblkid" uniqueId="fedora_19-i686-libblkid-2.23.1-3.fc19" version="2.23.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libblkid.so.1"/>
     <File location="/usr/lib" name="libblkid.so.1.1.0"/>
@@ -13728,7 +13728,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsemanage" uniqueId="fedora_19-i686-libsemanage-2.1.10-4.fc19" version="2.1.10-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/selinux" name="semanage.conf"/>
     <File location="/usr/lib" name="libsemanage.so.1"/>
@@ -13737,7 +13737,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libutempter" uniqueId="fedora_19-i686-libutempter-1.1.6-2.fc19" version="1.1.6-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libutempter.so.0"/>
     <File location="/usr/lib" name="libutempter.so.1.1.6"/>
@@ -13749,7 +13749,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dbus" uniqueId="fedora_19-i686-dbus-1.6.8-5.fc19" version="1.6.8-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="dbus-cleanup-sockets"/>
     <File location="/bin" name="dbus-daemon"/>
@@ -13776,7 +13776,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="policycoreutils" uniqueId="fedora_19-i686-policycoreutils-2.1.14-45.fc19" version="2.1.14-45.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pam.d" name="run_init"/>
     <File location="/etc" name="sestatus.conf"/>
@@ -13905,7 +13905,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="fedora-logos" uniqueId="fedora_19-i686-fedora-logos-19.0.4-2.fc19" version="19.0.4-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/boot/grub2/themes/system" name="background.png"/>
     <File location="/boot/grub2/themes/system" name="fireworks.png"/>
@@ -14043,7 +14043,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-decorator" uniqueId="fedora_19-i686-python-decorator-3.4.0-2.fc19" version="3.4.0-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages/decorator-3.4.0-py2.7.egg-info" name="PKG-INFO"/>
     <File location="/usr/lib/python2.7/site-packages/decorator-3.4.0-py2.7.egg-info" name="SOURCES.txt"/>
@@ -14060,7 +14060,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cronie-anacron" uniqueId="fedora_19-i686-cronie-anacron-1.4.10-5.fc19" version="1.4.10-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="anacrontab"/>
     <File location="/etc/cron.hourly" name="0anacron"/>
@@ -14075,7 +14075,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="crontabs" uniqueId="fedora_19-i686-crontabs-1.11-5.20121102git.fc19" version="1.11-5.20121102git.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="crontab"/>
     <File location="/etc/sysconfig" name="run-parts"/>
@@ -14087,7 +14087,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="os-prober" uniqueId="fedora_19-i686-os-prober-1.58-1.fc19" version="1.58-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="linux-boot-prober"/>
     <File location="/usr/bin" name="os-prober"/>
@@ -14123,7 +14123,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="polkit-pkla-compat" uniqueId="fedora_19-i686-polkit-pkla-compat-0.1-2.fc19" version="0.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="pkla-admin-identities"/>
     <File location="/usr/bin" name="pkla-check-authorization"/>
@@ -14139,7 +14139,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssh" uniqueId="fedora_19-i686-openssh-6.2p2-3.fc19" version="6.2p2-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/ssh" name="moduli"/>
     <File location="/usr/bin" name="ssh-keygen"/>
@@ -14168,7 +14168,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dbus-python" uniqueId="fedora_19-i686-dbus-python-1.1.1-5.fc19" version="1.1.1-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages" name="_dbus_bindings.so"/>
     <File location="/usr/lib/python2.7/site-packages" name="_dbus_glib_bindings.so"/>
@@ -14238,7 +14238,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dhcp-common" uniqueId="fedora_19-i686-dhcp-common-4.2.5-12.fc19" version="4.2.5-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/dhcp-common-4.2.5" name="LICENSE"/>
     <File location="/usr/share/doc/dhcp-common-4.2.5" name="README"/>
@@ -14251,7 +14251,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pygpgme" uniqueId="fedora_19-i686-pygpgme-0.3-6.fc19" version="0.3-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages/gpgme" name="__init__.py"/>
     <File location="/usr/lib/python2.7/site-packages/gpgme" name="__init__.pyc"/>
@@ -14292,7 +14292,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpm-python" uniqueId="fedora_19-i686-rpm-python-4.11.0.1-2.fc19" version="4.11.0.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages/rpm" name="__init__.py"/>
     <File location="/usr/lib/python2.7/site-packages/rpm" name="__init__.pyc"/>
@@ -14308,7 +14308,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="device-mapper-event" uniqueId="fedora_19-i686-device-mapper-event-1.02.77-9.fc19" version="1.02.77-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/systemd/system" name="dm-event.service"/>
     <File location="/usr/lib/systemd/system" name="dm-event.socket"/>
@@ -14319,7 +14319,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dnsmasq" uniqueId="fedora_19-i686-dnsmasq-2.66-7.fc19" version="2.66-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dbus-1/system.d" name="dnsmasq.conf"/>
     <File location="/etc" name="dnsmasq.conf"/>
@@ -14337,7 +14337,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdrm" uniqueId="fedora_19-i686-libdrm-2.4.45-1.fc19" version="2.4.45-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/udev/rules.d" name="91-drm-modeset.rules"/>
     <File location="/usr/lib" name="libdrm.so.2"/>
@@ -14356,7 +14356,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grubby" uniqueId="fedora_19-i686-grubby-8.26-2.fc19" version="8.26-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="grubby"/>
     <File location="/sbin" name="installkernel"/>
@@ -14370,7 +14370,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="logrotate" uniqueId="fedora_19-i686-logrotate-3.8.4-1.fc19" version="3.8.4-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/cron.daily" name="logrotate"/>
     <File location="/etc" name="logrotate.conf"/>
@@ -14385,7 +14385,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kpartx" uniqueId="fedora_19-i686-kpartx-0.4.9-51.fc19" version="0.4.9-51.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="kpartx"/>
     <File location="/usr/share/man/man8" name="kpartx.8.gz"/>
@@ -14394,7 +14394,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnfsidmap" uniqueId="fedora_19-i686-libnfsidmap-0.25-5.fc19" version="0.25-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="idmapd.conf"/>
     <File location="/lib" name="libnfsidmap.so.0"/>
@@ -14414,7 +14414,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-urlgrabber" uniqueId="fedora_19-i686-python-urlgrabber-3.9.1-27.fc19" version="3.9.1-27.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="urlgrabber"/>
     <File location="/usr/lib/python2.7/site-packages" name="urlgrabber-3.9.1-py2.7.egg-info"/>
@@ -14443,7 +14443,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="newt-python" uniqueId="fedora_19-i686-newt-python-0.52.15-1.fc19" version="0.52.15-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages" name="_snackmodule.so"/>
     <File location="/usr/lib/python2.7/site-packages" name="snack.py"/>
@@ -14456,7 +14456,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pyliblzma" uniqueId="fedora_19-i686-pyliblzma-0.5.3-8.fc19" version="0.5.3-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages" name="liblzma.py"/>
     <File location="/usr/lib/python2.7/site-packages" name="liblzma.pyc"/>
@@ -14475,7 +14475,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libselinux-python" uniqueId="fedora_19-i686-libselinux-python-2.1.13-15.fc19" version="2.1.13-15.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages/selinux" name="__init__.py"/>
     <File location="/usr/lib/python2.7/site-packages/selinux" name="__init__.pyc"/>
@@ -14487,7 +14487,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-slip-dbus" uniqueId="fedora_19-i686-python-slip-dbus-0.4.0-1.fc19" version="0.4.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages" name="slip.dbus-0.4.0-py2.7.egg-info"/>
     <File location="/usr/lib/python2.7/site-packages/slip/dbus" name="__init__.py"/>
@@ -14528,7 +14528,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ppp" uniqueId="fedora_19-i686-ppp-2.4.5-29.fc19" version="2.4.5-29.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/logrotate.d" name="ppp"/>
     <File location="/etc/pam.d" name="ppp"/>
@@ -14606,7 +14606,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sysvinit-tools" uniqueId="fedora_19-i686-sysvinit-tools-2.88-10.dsf.fc19" version="2.88-10.dsf.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="killall5"/>
     <File location="/sbin" name="pidof"/>
@@ -14627,7 +14627,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssl-devel" uniqueId="fedora_19-i686-openssl-devel-1.0.1e-4.fc19" version="1.0.1e-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include/openssl" name="aes.h"/>
     <File location="/usr/include/openssl" name="asn1.h"/>
@@ -15883,7 +15883,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kernel-devel" uniqueId="fedora_19-i686-kernel-devel-3.9.5-301.fc19" version="3.9.5-301.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/src/kernels/3.9.5-301.fc19.i686" name=".config"/>
     <File location="/usr/src/kernels/3.9.5-301.fc19.i686" name="Kconfig"/>
@@ -26720,7 +26720,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="initscripts" uniqueId="fedora_19-i686-initscripts-9.47-1.fc19" version="9.47-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/NetworkManager/dispatcher.d" name="00-netreport"/>
     <File location="/etc" name="adjtime"/>
@@ -26918,7 +26918,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="plymouth-scripts" uniqueId="fedora_19-i686-plymouth-scripts-0.8.9-0.2013.03.26.0.fc19" version="0.8.9-0.2013.03.26.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/libexec/plymouth" name="plymouth-generate-initrd"/>
     <File location="/usr/libexec/plymouth" name="plymouth-populate-initrd"/>
@@ -26929,7 +26929,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cyrus-sasl" uniqueId="fedora_19-i686-cyrus-sasl-2.1.26-8.fc19" version="2.1.26-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/sysconfig" name="saslauthd"/>
     <File location="/usr/lib/systemd/system" name="saslauthd.service"/>
@@ -26947,7 +26947,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="setup" uniqueId="fedora_19-i686-setup-2.8.71-1.fc19" version="2.8.71-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="aliases"/>
     <File location="/etc" name="bashrc"/>
@@ -26981,7 +26981,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="avahi" uniqueId="fedora_19-i686-avahi-0.6.31-11.fc19" version="0.6.31-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/avahi" name="avahi-daemon.conf"/>
     <File location="/etc/avahi" name="hosts"/>
@@ -27062,13 +27062,13 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="basesystem" uniqueId="fedora_19-i686-basesystem-10.0-8.fc19" version="10.0-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ebtables" uniqueId="fedora_19-i686-ebtables-2.0.10-8.fc19" version="2.0.10-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="ethertypes"/>
     <File location="/etc/rc.d/init.d" name="ebtables"/>
@@ -27108,7 +27108,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tzdata" uniqueId="fedora_19-i686-tzdata-2013c-1.fc19" version="2013c-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/tzdata-2013c" name="README"/>
     <File location="/usr/share/doc/tzdata-2013c" name="Theory"/>
@@ -28873,7 +28873,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="firewalld" uniqueId="fedora_19-i686-firewalld-0.3.3-2.fc19" version="0.3.3-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dbus-1/system.d" name="FirewallD.conf"/>
     <File location="/etc/sysconfig" name="firewalld"/>
@@ -29050,7 +29050,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kbd-misc" uniqueId="fedora_19-i686-kbd-misc-1.15.5-6.fc19" version="1.15.5-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/kbd/consolefonts" name="161.cp.gz"/>
     <File location="/lib/kbd/consolefonts" name="162.cp.gz"/>
@@ -30055,7 +30055,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="NetworkManager" uniqueId="fedora_19-i686-NetworkManager-0.9.8.2-2.fc19" version="0.9.8.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/NetworkManager" name="NetworkManager.conf"/>
     <File location="/etc/dbus-1/system.d" name="nm-avahi-autoipd.conf"/>
@@ -30163,7 +30163,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="fedora-release" uniqueId="fedora_19-i686-fedora-release-19-2" version="19-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="fedora-release"/>
     <File location="/etc" name="issue"/>
@@ -30197,7 +30197,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kbd" uniqueId="fedora_19-i686-kbd-1.15.5-6.fc19" version="1.15.5-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="dumpkeys"/>
     <File location="/bin" name="kbd_mode"/>
@@ -30319,7 +30319,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses-base" uniqueId="fedora_19-i686-ncurses-base-5.9-11.20130511.fc19" version="5.9-11.20130511.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/ncurses-base-5.9" name="README"/>
     <File location="/usr/share/tabset" name="std"/>
@@ -30450,7 +30450,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rsyslog" uniqueId="fedora_19-i686-rsyslog-7.2.6-1.fc19" version="7.2.6-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/logrotate.d" name="syslog"/>
     <File location="/etc" name="rsyslog.conf"/>
@@ -30500,7 +30500,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgcc" uniqueId="fedora_19-i686-libgcc-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libgcc_s-4.8.1-20130603.so.1"/>
     <File location="/lib" name="libgcc_s.so.1"/>
@@ -30514,7 +30514,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gcc" uniqueId="fedora_19-i686-gcc-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="c89"/>
     <File location="/usr/bin" name="c99"/>
@@ -30664,7 +30664,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="glibc-common" uniqueId="fedora_19-i686-glibc-common-2.17-4.fc19" version="2.17-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/default" name="nss"/>
     <File location="/usr/bin" name="catchsegv"/>
@@ -31276,7 +31276,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssh-server" uniqueId="fedora_19-i686-openssh-server-6.2p2-3.fc19" version="6.2p2-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pam.d" name="sshd"/>
     <File location="/etc/ssh" name="sshd_config"/>
@@ -31298,7 +31298,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="glibc" uniqueId="fedora_19-i686-glibc-2.17-4.fc19" version="2.17-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="ld.so.cache"/>
     <File location="/etc" name="ld.so.conf"/>
@@ -31646,7 +31646,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="biosdevname" uniqueId="fedora_19-i686-biosdevname-0.4.1-4.fc19" version="0.4.1-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib/udev/rules.d" name="71-biosdevname.rules"/>
     <File location="/sbin" name="biosdevname"/>
@@ -31658,7 +31658,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses-libs" uniqueId="fedora_19-i686-ncurses-libs-5.9-11.20130511.fc19" version="5.9-11.20130511.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libform.so.5"/>
     <File location="/usr/lib" name="libform.so.5.9"/>
@@ -31689,7 +31689,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="net-tools" uniqueId="fedora_19-i686-net-tools-2.0-0.6.20130109git.fc19" version="2.0-0.6.20130109git.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="netstat"/>
     <File location="/sbin" name="arp"/>
@@ -31746,7 +31746,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsepol" uniqueId="fedora_19-i686-libsepol-2.1.9-1.fc19" version="2.1.9-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libsepol.so.1"/>
   </Payload>
@@ -31754,7 +31754,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="e2fsprogs" uniqueId="fedora_19-i686-e2fsprogs-1.42.7-2.fc19" version="1.42.7-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="e2fsck.conf"/>
     <File location="/etc" name="mke2fs.conf"/>
@@ -31831,7 +31831,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcap" uniqueId="fedora_19-i686-libcap-2.22-6.fc19" version="2.22-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libcap.so.2"/>
     <File location="/usr/lib" name="libcap.so.2.22"/>
@@ -31851,7 +31851,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="passwd" uniqueId="fedora_19-i686-passwd-0.78.99-4.fc19" version="0.78.99-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pam.d" name="passwd"/>
     <File location="/usr/bin" name="passwd"/>
@@ -31931,7 +31931,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libselinux" uniqueId="fedora_19-i686-libselinux-2.1.13-15.fc19" version="2.1.13-15.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libselinux.so.1"/>
     <File location="/usr/lib/tmpfiles.d" name="libselinux.conf"/>
@@ -31941,7 +31941,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="wget" uniqueId="fedora_19-i686-wget-1.14-5.fc19" version="1.14-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="wgetrc"/>
     <File location="/usr/bin" name="wget"/>
@@ -31997,7 +31997,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="info" uniqueId="fedora_19-i686-info-5.1-1.fc19" version="5.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="install-info"/>
     <File location="/usr/bin" name="info"/>
@@ -32015,7 +32015,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tar" uniqueId="fedora_19-i686-tar-1.26-24.fc19" version="1.26-24.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="gtar"/>
     <File location="/usr/bin" name="tar"/>
@@ -32073,7 +32073,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="audit-libs" uniqueId="fedora_19-i686-audit-libs-2.3.1-2.fc19" version="2.3.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="libaudit.conf"/>
     <File location="/lib" name="libaudit.so.1"/>
@@ -32086,7 +32086,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-setuptools" uniqueId="fedora_19-i686-python-setuptools-0.6.49-1.fc19" version="0.6.49-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="easy_install"/>
     <File location="/usr/bin" name="easy_install-2.7"/>
@@ -32245,7 +32245,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libacl" uniqueId="fedora_19-i686-libacl-2.2.51-9.fc19" version="2.2.51-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libacl.so.1"/>
     <File location="/usr/lib" name="libacl.so.1.1.0"/>
@@ -32254,7 +32254,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Error" uniqueId="fedora_19-i686-perl-Error-0.17020-1.fc19" version="0.17020-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/doc/perl-Error-0.17020" name="ChangeLog"/>
     <File location="/usr/share/doc/perl-Error-0.17020" name="README"/>
@@ -32274,7 +32274,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="chkconfig" uniqueId="fedora_19-i686-chkconfig-1.3.60-3.fc19" version="1.3.60-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/sbin" name="chkconfig"/>
     <File location="/usr/sbin" name="alternatives"/>
@@ -32358,7 +32358,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rsync" uniqueId="fedora_19-i686-rsync-3.0.9-12.fc19" version="3.0.9-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="rsyncd.conf"/>
     <File location="/etc/sysconfig" name="rsyncd"/>
@@ -32392,7 +32392,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dbus-libs" uniqueId="fedora_19-i686-dbus-libs-1.6.8-5.fc19" version="1.6.8-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libdbus-1.so.3"/>
     <File location="/lib" name="libdbus-1.so.3.7.2"/>
@@ -32401,7 +32401,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="git" uniqueId="fedora_19-i686-git-1.8.3.1-1.fc19" version="1.8.3.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/bash_completion.d" name="git"/>
     <File location="/usr/bin" name="git"/>
@@ -33607,7 +33607,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nspr" uniqueId="fedora_19-i686-nspr-4.9.6-1.fc19" version="4.9.6-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libnspr4.so"/>
     <File location="/usr/lib" name="libplc4.so"/>
@@ -33617,7 +33617,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-chardet" uniqueId="fedora_19-i686-python-chardet-2.0.1-6.fc19" version="2.0.1-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages" name="chardet-2.0.1-py2.7.egg-info"/>
     <File location="/usr/lib/python2.7/site-packages/chardet" name="__init__.py"/>
@@ -33734,7 +33734,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss-util" uniqueId="fedora_19-i686-nss-util-3.14.3-1.fc19" version="3.14.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libnssutil3.so"/>
   </Payload>
@@ -33742,7 +33742,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="yum-utils" uniqueId="fedora_19-i686-yum-utils-1.1.31-18.fc19" version="1.1.31-18.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/bash_completion.d" name="yum-utils.bash"/>
     <File location="/usr/bin" name="debuginfo-install"/>
@@ -33807,7 +33807,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bzip2-libs" uniqueId="fedora_19-i686-bzip2-libs-1.0.6-8.fc19" version="1.0.6-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libbz2.so.1"/>
     <File location="/usr/lib" name="libbz2.so.1.0.6"/>
@@ -33817,7 +33817,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="readline" uniqueId="fedora_19-i686-readline-6.2-6.fc19" version="6.2-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libreadline.so.6"/>
     <File location="/lib" name="libreadline.so.6.2"/>
@@ -33835,7 +33835,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgpg-error" uniqueId="fedora_19-i686-libgpg-error-1.11-1.fc19" version="1.11-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libgpg-error.so.0"/>
     <File location="/lib" name="libgpg-error.so.0.9.0"/>
@@ -33865,7 +33865,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="keyutils-libs" uniqueId="fedora_19-i686-keyutils-libs-1.5.5-4.fc19" version="1.5.5-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libkeyutils.so.1"/>
     <File location="/lib" name="libkeyutils.so.1.4"/>
@@ -33875,7 +33875,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="findutils" uniqueId="fedora_19-i686-findutils-4.5.11-1.fc19" version="4.5.11-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="find"/>
     <File location="/usr/bin" name="oldfind"/>
@@ -33938,7 +33938,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libidn" uniqueId="fedora_19-i686-libidn-1.26-2.fc19" version="1.26-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libidn.so.11"/>
     <File location="/lib" name="libidn.so.11.6.9"/>
@@ -33979,7 +33979,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lua" uniqueId="fedora_19-i686-lua-5.1.4-12.fc19" version="5.1.4-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="lua"/>
     <File location="/usr/bin" name="luac"/>
@@ -34004,7 +34004,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libffi" uniqueId="fedora_19-i686-libffi-3.0.13-4.fc19" version="3.0.13-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libffi.so.6"/>
     <File location="/usr/lib" name="libffi.so.6.0.1"/>
@@ -34015,7 +34015,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="glib2" uniqueId="fedora_19-i686-glib2-2.36.3-2.fc19" version="2.36.3-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="gdbus"/>
     <File location="/usr/bin" name="gio-querymodules-32"/>
@@ -34141,7 +34141,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="elfutils-libelf" uniqueId="fedora_19-i686-elfutils-libelf-0.155-5.fc19" version="0.155-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libelf-0.155.so"/>
     <File location="/usr/lib" name="libelf.so.1"/>
@@ -34157,7 +34157,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mpfr" uniqueId="fedora_19-i686-mpfr-3.1.1-2.fc19" version="3.1.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libmpfr.so.4"/>
     <File location="/usr/lib" name="libmpfr.so.4.1.1"/>
@@ -34182,7 +34182,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgomp" uniqueId="fedora_19-i686-libgomp-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libgomp.so.1"/>
     <File location="/usr/lib" name="libgomp.so.1.0.0"/>
@@ -34194,7 +34194,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="file-libs" uniqueId="fedora_19-i686-file-libs-5.11-9.fc19" version="5.11-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libmagic.so.1"/>
     <File location="/usr/lib" name="libmagic.so.1.0.0"/>
@@ -34211,7 +34211,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcap-ng" uniqueId="fedora_19-i686-libcap-ng-0.7.3-3.fc19" version="0.7.3-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libcap-ng.so.0"/>
     <File location="/lib" name="libcap-ng.so.0.0.0"/>
@@ -34221,7 +34221,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gdbm" uniqueId="fedora_19-i686-gdbm-1.10-6.fc19" version="1.10-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="testgdbm"/>
     <File location="/usr/lib" name="libgdbm.so.4"/>
@@ -34244,7 +34244,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Pod-Escapes" uniqueId="fedora_19-i686-perl-Pod-Escapes-1.04-264.fc19" version="1.04-264.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man3" name="Pod::Escapes.3pm.gz"/>
     <File location="/usr/share/perl5/Pod" name="Escapes.pm"/>
@@ -34253,7 +34253,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-macros" uniqueId="fedora_19-i686-perl-macros-5.16.3-264.fc19" version="5.16.3-264.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/rpm" name="macros.perl"/>
   </Payload>
@@ -34261,7 +34261,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Scalar-List-Utils" uniqueId="fedora_19-i686-perl-Scalar-List-Utils-1.27-246.fc19" version="1.27-246.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/vendor_perl/List" name="Util.pm"/>
     <File location="/usr/lib/perl5/vendor_perl/List/Util" name="XS.pm"/>
@@ -34277,7 +34277,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-PathTools" uniqueId="fedora_19-i686-perl-PathTools-3.40-1.fc19" version="3.40-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/vendor_perl" name="Cwd.pm"/>
     <File location="/usr/lib/perl5/vendor_perl/File" name="Spec.pm"/>
@@ -34307,7 +34307,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Socket" uniqueId="fedora_19-i686-perl-Socket-2.009-2.fc19" version="2.009-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/perl5/vendor_perl" name="Socket.pm"/>
     <File location="/usr/lib/perl5/vendor_perl/auto/Socket" name="Socket.so"/>
@@ -34321,7 +34321,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Pod-Simple" uniqueId="fedora_19-i686-perl-Pod-Simple-3.20-264.fc19" version="3.20-264.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/share/man/man3" name="Pod::Simple.3pm.gz"/>
     <File location="/usr/share/man/man3" name="Pod::Simple::Checker.3pm.gz"/>
@@ -34380,7 +34380,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtasn1" uniqueId="fedora_19-i686-libtasn1-3.3-1.fc19" version="3.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libtasn1.so.6"/>
     <File location="/usr/lib" name="libtasn1.so.6.1.1"/>
@@ -34397,7 +34397,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libee" uniqueId="fedora_19-i686-libee-0.4.1-4.fc19" version="0.4.1-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libee.so.0"/>
     <File location="/usr/lib" name="libee.so.0.0.0"/>
@@ -34410,7 +34410,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmpc" uniqueId="fedora_19-i686-libmpc-1.0.1-1.fc19" version="1.0.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libmpc.so.3"/>
     <File location="/usr/lib" name="libmpc.so.3.0.0"/>
@@ -34422,7 +34422,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libassuan" uniqueId="fedora_19-i686-libassuan-2.0.3-5.fc19" version="2.0.3-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libassuan.so.0"/>
     <File location="/usr/lib" name="libassuan.so.0.3.0"/>
@@ -34439,7 +34439,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kmod-libs" uniqueId="fedora_19-i686-kmod-libs-13-2.fc19" version="13-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libkmod.so.2"/>
     <File location="/usr/lib" name="libkmod.so.2.2.3"/>
@@ -34448,7 +34448,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="e2fsprogs-libs" uniqueId="fedora_19-i686-e2fsprogs-libs-1.42.7-2.fc19" version="1.42.7-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libe2p.so.2"/>
     <File location="/usr/lib" name="libe2p.so.2.3"/>
@@ -34460,7 +34460,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libunistring" uniqueId="fedora_19-i686-libunistring-0.9.3-7.fc19" version="0.9.3-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libunistring.so.0"/>
     <File location="/usr/lib" name="libunistring.so.0.1.2"/>
@@ -34472,7 +34472,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="krb5-libs" uniqueId="fedora_19-i686-krb5-libs-1.11.3-1.fc19" version="1.11.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="krb5.conf"/>
     <File location="/usr/lib/krb5/plugins/kdb" name="db2.so"/>
@@ -34511,7 +34511,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdaemon" uniqueId="fedora_19-i686-libdaemon-0.14-5.fc19" version="0.14-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libdaemon.so.0"/>
     <File location="/usr/lib" name="libdaemon.so.0.5.0"/>
@@ -34522,7 +34522,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnl3" uniqueId="fedora_19-i686-libnl3-3.2.21-1.fc19" version="3.2.21-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/libnl" name="classid"/>
     <File location="/etc/libnl" name="pktloc"/>
@@ -34540,7 +34540,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libverto-devel" uniqueId="fedora_19-i686-libverto-devel-0.2.5-2.fc19" version="0.2.5-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include" name="verto-module.h"/>
     <File location="/usr/include" name="verto.h"/>
@@ -34551,7 +34551,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcom_err-devel" uniqueId="fedora_19-i686-libcom_err-devel-1.42.7-2.fc19" version="1.42.7-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="compile_et"/>
     <File location="/usr/include" name="com_err.h"/>
@@ -34567,7 +34567,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsepol-devel" uniqueId="fedora_19-i686-libsepol-devel-2.1.9-1.fc19" version="2.1.9-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include/sepol" name="boolean_record.h"/>
     <File location="/usr/include/sepol" name="booleans.h"/>
@@ -34618,7 +34618,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="keyutils-libs-devel" uniqueId="fedora_19-i686-keyutils-libs-devel-1.5.5-4.fc19" version="1.5.5-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include" name="keyutils.h"/>
     <File location="/usr/lib" name="libkeyutils.so"/>
@@ -34652,7 +34652,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="glibc-devel" uniqueId="fedora_19-i686-glibc-devel-2.17-4.fc19" version="2.17-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include/gnu" name="stubs-32.h"/>
     <File location="/usr/lib" name="Mcrt1.o"/>
@@ -34708,7 +34708,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="newt" uniqueId="fedora_19-i686-newt-0.52.15-1.fc19" version="0.52.15-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="whiptail"/>
     <File location="/usr/lib" name="libnewt.so.0.52"/>
@@ -34793,7 +34793,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="less" uniqueId="fedora_19-i686-less-458-3.fc19" version="458-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/profile.d" name="less.csh"/>
     <File location="/etc/profile.d" name="less.sh"/>
@@ -34810,7 +34810,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblognorm" uniqueId="fedora_19-i686-liblognorm-0.3.5-1.fc19" version="0.3.5-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="liblognorm.so.0"/>
     <File location="/usr/lib" name="liblognorm.so.0.0.0"/>
@@ -34824,7 +34824,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ca-certificates" uniqueId="fedora_19-i686-ca-certificates-2012.87-10.2.fc19" version="2012.87-10.2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pki/ca-trust" name="README"/>
     <File location="/etc/pki/ca-trust/extracted" name="README"/>
@@ -34851,7 +34851,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libssh2" uniqueId="fedora_19-i686-libssh2-1.4.3-4.fc19" version="1.4.3-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libssh2.so.1"/>
     <File location="/usr/lib" name="libssh2.so.1.0.1"/>
@@ -34865,7 +34865,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bind-libs-lite" uniqueId="fedora_19-i686-bind-libs-lite-9.9.3-3.P1.fc19" version="9.9.3-3.P1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libdns-export.so.99"/>
     <File location="/usr/lib" name="libdns-export.so.99.0.1"/>
@@ -34880,7 +34880,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="fipscheck" uniqueId="fedora_19-i686-fipscheck-1.3.1-3.fc19" version="1.3.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="fipscheck"/>
     <File location="/usr/bin" name="fipshmac"/>
@@ -34896,7 +34896,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss-softokn" uniqueId="fedora_19-i686-nss-softokn-3.14.3-1.fc19" version="3.14.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libnssdbm3.chk"/>
     <File location="/usr/lib" name="libnssdbm3.so"/>
@@ -34910,7 +34910,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="device-mapper-persistent-data" uniqueId="fedora_19-i686-device-mapper-persistent-data-0.1.4-3.fc19" version="0.1.4-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/sbin" name="thin_check"/>
     <File location="/usr/sbin" name="thin_dump"/>
@@ -34925,7 +34925,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nettle" uniqueId="fedora_19-i686-nettle-2.6-2.fc19" version="2.6-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="nettle-hash"/>
     <File location="/usr/bin" name="nettle-lfib-stream"/>
@@ -34947,7 +34947,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmicrohttpd" uniqueId="fedora_19-i686-libmicrohttpd-0.9.27-1.fc19" version="0.9.27-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libmicrohttpd.so.10"/>
     <File location="/usr/lib" name="libmicrohttpd.so.10.17.0"/>
@@ -34957,7 +34957,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mozjs17" uniqueId="fedora_19-i686-mozjs17-17.0.0-7.fc19" version="17.0.0-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libmozjs-17.0.so"/>
     <File location="/usr/share/doc/mozjs17-17.0.0" name="LICENSE"/>
@@ -34967,7 +34967,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pinentry" uniqueId="fedora_19-i686-pinentry-0.8.1-10.fc19" version="0.8.1-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="pinentry"/>
     <File location="/usr/bin" name="pinentry-curses"/>
@@ -34984,7 +34984,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="vim-minimal" uniqueId="fedora_19-i686-vim-minimal-7.3.944-1.fc19" version="7.3.944-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="virc"/>
     <File location="/usr/bin" name="ex"/>
@@ -34997,7 +34997,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libss" uniqueId="fedora_19-i686-libss-1.42.7-2.fc19" version="1.42.7-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libss.so.2"/>
     <File location="/usr/lib" name="libss.so.2.0"/>
@@ -35007,7 +35007,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="diffutils" uniqueId="fedora_19-i686-diffutils-3.3-1.fc19" version="3.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="cmp"/>
     <File location="/usr/bin" name="diff"/>
@@ -35057,7 +35057,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="make" uniqueId="fedora_19-i686-make-3.82-15.fc19" version="3.82-15.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="gmake"/>
     <File location="/usr/bin" name="make"/>
@@ -35099,7 +35099,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="procmail" uniqueId="fedora_19-i686-procmail-3.22-32.fc19" version="3.22-32.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="formail"/>
     <File location="/usr/bin" name="lockfile"/>
@@ -35139,7 +35139,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses" uniqueId="fedora_19-i686-ncurses-5.9-11.20130511.fc19" version="5.9-11.20130511.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="captoinfo"/>
     <File location="/usr/bin" name="clear"/>
@@ -35174,7 +35174,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libedit" uniqueId="fedora_19-i686-libedit-3.0-10.20121213cvs.fc19" version="3.0-10.20121213cvs.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libedit.so.0"/>
     <File location="/usr/lib" name="libedit.so.0.0.42"/>
@@ -35186,7 +35186,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="plymouth-core-libs" uniqueId="fedora_19-i686-plymouth-core-libs-0.8.9-0.2013.03.26.0.fc19" version="0.8.9-0.2013.03.26.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libply-boot-client.so.2"/>
     <File location="/usr/lib" name="libply-boot-client.so.2.1.0"/>
@@ -35199,7 +35199,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iproute" uniqueId="fedora_19-i686-iproute-3.9.0-1.fc19" version="3.9.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/iproute2" name="ematch_map"/>
     <File location="/etc/iproute2" name="group"/>
@@ -35296,7 +35296,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pciutils-libs" uniqueId="fedora_19-i686-pciutils-libs-3.2.0-2.fc19" version="3.2.0-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/lib" name="libpci.so.3"/>
     <File location="/lib" name="libpci.so.3.2.0"/>
@@ -35306,7 +35306,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpipeline" uniqueId="fedora_19-i686-libpipeline-1.2.3-1.fc19" version="1.2.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libpipeline.so.1"/>
     <File location="/usr/lib" name="libpipeline.so.1.2.3"/>
@@ -35319,7 +35319,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ustr" uniqueId="fedora_19-i686-ustr-1.0.4-14.fc19" version="1.0.4-14.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libustr-1.0.so.1"/>
     <File location="/usr/lib" name="libustr-1.0.so.1.0.4"/>
@@ -35335,7 +35335,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python" uniqueId="fedora_19-i686-python-2.7.5-1.fc19" version="2.7.5-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="pydoc"/>
     <File location="/usr/bin" name="python"/>
@@ -35351,7 +35351,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcurl" uniqueId="fedora_19-i686-libcurl-7.29.0-6.fc19" version="7.29.0-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libcurl.so.4"/>
     <File location="/usr/lib" name="libcurl.so.4.3.0"/>
@@ -35360,7 +35360,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="device-mapper" uniqueId="fedora_19-i686-device-mapper-1.02.77-9.fc19" version="1.02.77-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/udev/rules.d" name="10-dm.rules"/>
     <File location="/usr/lib/udev/rules.d" name="13-dm-disk.rules"/>
@@ -35379,7 +35379,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cracklib" uniqueId="fedora_19-i686-cracklib-2.8.22-3.fc19" version="2.8.22-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libcrack.so.2"/>
     <File location="/usr/lib" name="libcrack.so.2.8.1"/>
@@ -35441,7 +35441,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openldap" uniqueId="fedora_19-i686-openldap-2.4.35-4.fc19" version="2.4.35-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/openldap" name="ldap.conf"/>
     <File location="/usr/lib" name="liblber-2.4.so.2"/>
@@ -35465,7 +35465,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="device-mapper-libs" uniqueId="fedora_19-i686-device-mapper-libs-1.02.77-9.fc19" version="1.02.77-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libdevmapper.so.1.02"/>
   </Payload>
@@ -35473,7 +35473,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpwquality" uniqueId="fedora_19-i686-libpwquality-1.2.1-2.fc19" version="1.2.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/security" name="pwquality.conf"/>
     <File location="/lib" name="libpwquality.so.1"/>
@@ -35540,7 +35540,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="systemd-sysv" uniqueId="fedora_19-i686-systemd-sysv-204-8.fc19" version="204-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="systemd-sysv-convert"/>
   </Payload>
@@ -35548,7 +35548,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpm" uniqueId="fedora_19-i686-rpm-4.11.0.1-2.fc19" version="4.11.0.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/bin" name="rpm"/>
     <File location="/usr/bin" name="rpm2cpio"/>
@@ -35709,7 +35709,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="coreutils" uniqueId="fedora_19-i686-coreutils-8.21-11.fc19" version="8.21-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="DIR_COLORS"/>
     <File location="/etc" name="DIR_COLORS.256color"/>
@@ -36025,7 +36025,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="systemd-libs" uniqueId="fedora_19-i686-systemd-libs-204-8.fc19" version="204-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libnss_myhostname.so.2"/>
     <File location="/usr/lib" name="libsystemd-daemon.so.0"/>
@@ -36044,7 +36044,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss-sysinit" uniqueId="fedora_19-i686-nss-sysinit-3.14.3-13.0.fc19" version="3.14.3-13.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pki/nssdb" name="cert9.db"/>
     <File location="/etc/pki/nssdb" name="key4.db"/>
@@ -36056,7 +36056,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="shadow-utils" uniqueId="fedora_19-i686-shadow-utils-4.1.5.1-5.fc19" version="4.1.5.1-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/default" name="useradd"/>
     <File location="/etc" name="login.defs"/>
@@ -36390,7 +36390,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="util-linux" uniqueId="fedora_19-i686-util-linux-2.23.1-3.fc19" version="2.23.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="mtab"/>
     <File location="/etc/pam.d" name="chfn"/>
@@ -36726,7 +36726,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="systemd" uniqueId="fedora_19-i686-systemd-204-8.fc19" version="204-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/X11/xorg.conf.d" name="00-keyboard.conf"/>
     <File location="/etc/dbus-1/system.d" name="org.freedesktop.hostname1.conf"/>
@@ -37331,7 +37331,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="selinux-policy" uniqueId="fedora_19-i686-selinux-policy-3.12.1-54.fc19" version="3.12.1-54.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/selinux" name="config"/>
     <File location="/etc/sysconfig" name="selinux"/>
@@ -37341,7 +37341,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dhcp-libs" uniqueId="fedora_19-i686-dhcp-libs-4.2.5-12.fc19" version="4.2.5-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libdhcpctl.so.0"/>
     <File location="/usr/lib" name="libdhcpctl.so.0.0.0"/>
@@ -37352,7 +37352,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="device-mapper-event-libs" uniqueId="fedora_19-i686-device-mapper-event-libs-1.02.77-9.fc19" version="1.02.77-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libdevmapper-event.so.1.02"/>
   </Payload>
@@ -37360,7 +37360,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cronie" uniqueId="fedora_19-i686-cronie-1.4.10-5.fc19" version="1.4.10-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/cron.d" name="0hourly"/>
     <File location="/etc" name="cron.deny"/>
@@ -37383,7 +37383,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iputils" uniqueId="fedora_19-i686-iputils-20121221-2.fc19" version="20121221-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/sysconfig" name="rdisc"/>
     <File location="/usr/bin" name="ping"/>
@@ -37413,7 +37413,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="polkit" uniqueId="fedora_19-i686-polkit-0.111-2.fc19" version="0.111-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dbus-1/system.d" name="org.freedesktop.PolicyKit1.conf"/>
     <File location="/etc/pam.d" name="polkit-1"/>
@@ -37447,7 +37447,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgudev1" uniqueId="fedora_19-i686-libgudev1-204-8.fc19" version="204-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/girepository-1.0" name="GUdev-1.0.typelib"/>
     <File location="/usr/lib" name="libgudev-1.0.so.0"/>
@@ -37457,7 +37457,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gnupg2" uniqueId="fedora_19-i686-gnupg2-2.0.19-8.fc19" version="2.0.19-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="gpg-agent"/>
     <File location="/usr/bin" name="gpg-connect-agent"/>
@@ -37574,7 +37574,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gettext" uniqueId="fedora_19-i686-gettext-0.18.2.1-1.fc19" version="0.18.2.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="envsubst"/>
     <File location="/usr/bin" name="gettext"/>
@@ -37730,7 +37730,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-iniparse" uniqueId="fedora_19-i686-python-iniparse-0.4-7.fc19" version="0.4-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages" name="iniparse-0.4-py2.7.egg-info"/>
     <File location="/usr/lib/python2.7/site-packages/iniparse" name="__init__.py"/>
@@ -37759,7 +37759,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gpgme" uniqueId="fedora_19-i686-gpgme-1.3.2-3.fc19" version="1.3.2-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libgpgme-pthread.so.11"/>
     <File location="/usr/lib" name="libgpgme-pthread.so.11.8.1"/>
@@ -37779,7 +37779,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpm-build-libs" uniqueId="fedora_19-i686-rpm-build-libs-4.11.0.1-2.fc19" version="4.11.0.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="librpmbuild.so.3"/>
     <File location="/usr/lib" name="librpmbuild.so.3.1.0"/>
@@ -37790,7 +37790,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="NetworkManager-glib" uniqueId="fedora_19-i686-NetworkManager-glib-0.9.8.2-2.fc19" version="0.9.8.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/girepository-1.0" name="NMClient-1.0.typelib"/>
     <File location="/usr/lib/girepository-1.0" name="NetworkManager-1.0.typelib"/>
@@ -37805,7 +37805,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lvm2-libs" uniqueId="fedora_19-i686-lvm2-libs-2.02.98-9.fc19" version="2.02.98-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/device-mapper" name="libdevmapper-event-lvm2mirror.so"/>
     <File location="/usr/lib/device-mapper" name="libdevmapper-event-lvm2raid.so"/>
@@ -37823,7 +37823,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpcbind" uniqueId="fedora_19-i686-rpcbind-0.2.0-21.fc19" version="0.2.0-21.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/sysconfig" name="rpcbind"/>
     <File location="/sbin" name="rpcbind"/>
@@ -37840,7 +37840,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="wpa_supplicant" uniqueId="fedora_19-i686-wpa_supplicant-2.0-3.fc19" version="2.0-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/dbus-1/system.d" name="wpa_supplicant.conf"/>
     <File location="/etc/logrotate.d" name="wpa_supplicant"/>
@@ -37896,7 +37896,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="binutils" uniqueId="fedora_19-i686-binutils-2.23.52.0.1-8.fc19" version="2.23.52.0.1-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/bin" name="addr2line"/>
     <File location="/usr/bin" name="ar"/>
@@ -38045,7 +38045,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssl" uniqueId="fedora_19-i686-openssl-1.0.1e-4.fc19" version="1.0.1e-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/pki/tls/certs" name="Makefile"/>
     <File location="/etc/pki/tls/certs" name="make-dummy-cert"/>
@@ -38126,7 +38126,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dracut" uniqueId="fedora_19-i686-dracut-029-1.fc19" version="029-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc" name="dracut.conf"/>
     <File location="/etc/kernel/postinst.d" name="51-dracut-rescue-postinst.sh"/>
@@ -38371,7 +38371,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-pycurl" uniqueId="fedora_19-i686-python-pycurl-7.19.0-15.1.fc19" version="7.19.0-15.1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages/curl" name="__init__.py"/>
     <File location="/usr/lib/python2.7/site-packages/curl" name="__init__.pyc"/>
@@ -38429,7 +38429,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pyxattr" uniqueId="fedora_19-i686-pyxattr-0.5.1-3.fc19" version="0.5.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages/pyxattr-0.5.1-py2.7.egg-info" name="PKG-INFO"/>
     <File location="/usr/lib/python2.7/site-packages/pyxattr-0.5.1-py2.7.egg-info" name="SOURCES.txt"/>
@@ -38444,7 +38444,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="yum-metadata-parser" uniqueId="fedora_19-i686-yum-metadata-parser-1.1.4-8.fc19" version="1.1.4-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages" name="_sqlitecache.so"/>
     <File location="/usr/lib/python2.7/site-packages" name="sqlitecachec.py"/>
@@ -38459,7 +38459,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pygobject3-base" uniqueId="fedora_19-i686-pygobject3-base-3.8.2-2.fc19" version="3.8.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libpyglib-gi-2.0-python.so"/>
     <File location="/usr/lib" name="libpyglib-gi-2.0-python.so.0"/>
@@ -38549,7 +38549,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-slip" uniqueId="fedora_19-i686-python-slip-0.4.0-1.fc19" version="0.4.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib/python2.7/site-packages" name="slip-0.4.0-py2.7.egg-info"/>
     <File location="/usr/lib/python2.7/site-packages/slip" name="__init__.py"/>
@@ -38585,7 +38585,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpcap" uniqueId="fedora_19-i686-libpcap-1.4.0-1.fc19" version="1.4.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libpcap.so.1"/>
     <File location="/usr/lib" name="libpcap.so.1.4.0"/>
@@ -38601,7 +38601,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="json-c" uniqueId="fedora_19-i686-json-c-0.11-1.fc19" version="0.11-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/lib" name="libjson-c.so.2"/>
     <File location="/usr/lib" name="libjson-c.so.2.0.1"/>
@@ -38618,7 +38618,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="yum" uniqueId="fedora_19-i686-yum-3.4.3-99.fc19" version="3.4.3-99.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/logrotate.d" name="yum"/>
     <File location="/etc" name="yum.conf"/>
@@ -38775,7 +38775,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="selinux-policy-targeted" uniqueId="fedora_19-i686-selinux-policy-targeted-3.12.1-54.fc19" version="3.12.1-54.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/selinux/targeted" name=".policy.sha512"/>
     <File location="/etc/selinux/targeted" name="booleans.subs_dist"/>
@@ -38817,7 +38817,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="readline-devel" uniqueId="fedora_19-i686-readline-devel-6.2-6.fc19" version="6.2-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/include/readline" name="chardefs.h"/>
     <File location="/usr/include/readline" name="history.h"/>
@@ -38859,7 +38859,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kernel-PAE-devel" uniqueId="fedora_19-i686-kernel-PAE-devel-3.9.5-301.fc19" version="3.9.5-301.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/usr/src/kernels/3.9.5-301.fc19.i686.PAE" name=".config"/>
     <File location="/usr/src/kernels/3.9.5-301.fc19.i686.PAE" name="Kconfig"/>
@@ -49678,7 +49678,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dhclient" uniqueId="fedora_19-i686-dhclient-4.2.5-12.fc19" version="4.2.5-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/NetworkManager/dispatcher.d" name="11-dhclient"/>
     <File location="/usr/lib/pm-utils/sleep.d" name="56dhclient"/>
@@ -49696,7 +49696,7 @@
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="plymouth" uniqueId="fedora_19-i686-plymouth-0.8.9-0.2013.03.26.0.fc19" version="0.8.9-0.2013.03.26.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
   <Payload>
     <File location="/etc/plymouth" name="plymouthd.conf"/>
     <File location="/lib/systemd/system/halt.target.wants" name="plymouth-halt.service"/>

--- a/tests/dumps/swid_tags/rpm-swid.txt
+++ b/tests/dumps/swid_tags/rpm-swid.txt
@@ -1,1464 +1,1464 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="avahi-libs" uniqueId="fedora_19-i686-avahi-libs-0.6.31-11.fc19" version="0.6.31-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="filesystem" uniqueId="fedora_19-i686-filesystem-3.2-10.fc19" version="3.2-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="avahi-autoipd" uniqueId="fedora_19-i686-avahi-autoipd-0.6.31-11.fc19" version="0.6.31-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-firmware" uniqueId="fedora_19-i686-linux-firmware-20130418-0.1.gitb584174.fc19" version="20130418-0.1.gitb584174.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="quota" uniqueId="fedora_19-i686-quota-4.01-6.fc19" version="4.01-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="quota-nls" uniqueId="fedora_19-i686-quota-nls-4.01-6.fc19" version="4.01-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nfs-utils" uniqueId="fedora_19-i686-nfs-utils-1.2.8-2.0.fc19" version="1.2.8-2.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hwdata" uniqueId="fedora_19-i686-hwdata-0.247-1.fc19" version="0.247-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sendmail" uniqueId="fedora_19-i686-sendmail-8.14.7-1.fc19" version="8.14.7-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bind-license" uniqueId="fedora_19-i686-bind-license-9.9.3-3.P1.fc19" version="9.9.3-3.P1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kernel-PAE" uniqueId="fedora_19-i686-kernel-PAE-3.9.5-301.fc19" version="3.9.5-301.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kernel-headers" uniqueId="fedora_19-i686-kernel-headers-3.9.5-301.fc19" version="3.9.5-301.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="authconfig" uniqueId="fedora_19-i686-authconfig-6.2.6-3.fc19.1" version="6.2.6-3.fc19.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rootfiles" uniqueId="fedora_19-i686-rootfiles-8.1-10.fc19" version="8.1-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lvm2" uniqueId="fedora_19-i686-lvm2-2.02.98-9.fc19" version="2.02.98-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss-softokn-freebl" uniqueId="fedora_19-i686-nss-softokn-freebl-3.14.3-1.fc19" version="3.14.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssh-clients" uniqueId="fedora_19-i686-openssh-clients-6.2p2-3.fc19" version="6.2p2-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libstdc++" uniqueId="fedora_19-i686-libstdc++-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="audit" uniqueId="fedora_19-i686-audit-2.3.1-2.fc19" version="2.3.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bash" uniqueId="fedora_19-i686-bash-4.2.45-1.fc19" version="4.2.45-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="parted" uniqueId="fedora_19-i686-parted-3.1-12.fc19" version="3.1-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libattr" uniqueId="fedora_19-i686-libattr-2.4.46-10.fc19" version="2.4.46-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sudo" uniqueId="fedora_19-i686-sudo-1.8.6p7-1.fc19" version="1.8.6p7-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pcre" uniqueId="fedora_19-i686-pcre-8.32-7.fc19" version="8.32-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="man-db" uniqueId="fedora_19-i686-man-db-2.6.3-6.fc19" version="2.6.3-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="zlib" uniqueId="fedora_19-i686-zlib-1.2.7-10.fc19" version="1.2.7-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bzip2" uniqueId="fedora_19-i686-bzip2-1.0.6-8.fc19" version="1.0.6-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcom_err" uniqueId="fedora_19-i686-libcom_err-1.42.7-2.fc19" version="1.42.7-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gpg-pubkey" uniqueId="fedora_19-i686-gpg-pubkey-fb4b18e6-50b96bfd" version="fb4b18e6-50b96bfd" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdb" uniqueId="fedora_19-i686-libdb-5.3.21-11.fc19" version="5.3.21-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-pip" uniqueId="fedora_19-i686-python-pip-1.3.1-4.fc19" version="1.3.1-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="popt" uniqueId="fedora_19-i686-popt-1.13-14.fc19" version="1.13-14.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-TermReadKey" uniqueId="fedora_19-i686-perl-TermReadKey-2.30-18.fc19" version="2.30-18.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xz-libs" uniqueId="fedora_19-i686-xz-libs-5.1.2-4alpha.fc19" version="5.1.2-4alpha.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgnome-keyring" uniqueId="fedora_19-i686-libgnome-keyring-3.8.0-1.fc19" version="3.8.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sed" uniqueId="fedora_19-i686-sed-4.2.2-2.fc19" version="4.2.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Git" uniqueId="fedora_19-i686-perl-Git-1.8.3.1-1.fc19" version="1.8.3.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libuuid" uniqueId="fedora_19-i686-libuuid-2.23.1-3.fc19" version="2.23.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-kitchen" uniqueId="fedora_19-i686-python-kitchen-1.1.1-4.fc19" version="1.1.1-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grep" uniqueId="fedora_19-i686-grep-2.14-3.fc19" version="2.14-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tcp_wrappers-libs" uniqueId="fedora_19-i686-tcp_wrappers-libs-7.6-73.fc19" version="7.6-73.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gmp" uniqueId="fedora_19-i686-gmp-5.1.1-2.fc19" version="5.1.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgcrypt" uniqueId="fedora_19-i686-libgcrypt-1.5.2-1.fc19" version="1.5.2-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="expat" uniqueId="fedora_19-i686-expat-2.1.0-5.fc19" version="2.1.0-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gawk" uniqueId="fedora_19-i686-gawk-4.0.2-2.fc19" version="4.0.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sqlite" uniqueId="fedora_19-i686-sqlite-3.7.17-1.fc19" version="3.7.17-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libxml2" uniqueId="fedora_19-i686-libxml2-2.9.1-1.fc19" version="2.9.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pkgconfig" uniqueId="fedora_19-i686-pkgconfig-0.27.1-1.fc19" version="0.27.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="shared-mime-info" uniqueId="fedora_19-i686-shared-mime-info-1.1-4.fc19" version="1.1-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dbus-glib" uniqueId="fedora_19-i686-dbus-glib-0.100-4.fc19" version="0.100-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cyrus-sasl-lib" uniqueId="fedora_19-i686-cyrus-sasl-lib-2.1.26-8.fc19" version="2.1.26-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cpio" uniqueId="fedora_19-i686-cpio-2.11-20.fc19" version="2.11-20.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iptables" uniqueId="fedora_19-i686-iptables-1.4.18-1.fc19" version="1.4.18-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libestr" uniqueId="fedora_19-i686-libestr-0.1.5-1.fc19" version="0.1.5-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Encode" uniqueId="fedora_19-i686-perl-Encode-2.51-1.fc19" version="2.51-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-libs" uniqueId="fedora_19-i686-perl-libs-5.16.3-264.fc19" version="5.16.3-264.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-threads" uniqueId="fedora_19-i686-perl-threads-1.87-1.fc19" version="1.87-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-threads-shared" uniqueId="fedora_19-i686-perl-threads-shared-1.43-2.fc19" version="1.43-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Carp" uniqueId="fedora_19-i686-perl-Carp-1.26-243.fc19" version="1.26-243.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Filter" uniqueId="fedora_19-i686-perl-Filter-1.49-1.fc19" version="1.49-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl" uniqueId="fedora_19-i686-perl-5.16.3-264.fc19" version="5.16.3-264.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="p11-kit" uniqueId="fedora_19-i686-p11-kit-0.18.3-1.fc19" version="0.18.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="file" uniqueId="fedora_19-i686-file-5.11-9.fc19" version="5.11-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcroco" uniqueId="fedora_19-i686-libcroco-0.6.8-2.fc19" version="0.6.8-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="groff-base" uniqueId="fedora_19-i686-groff-base-1.22.2-2.fc19" version="1.22.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kmod" uniqueId="fedora_19-i686-kmod-13-2.fc19" version="13-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="which" uniqueId="fedora_19-i686-which-2.20-5.fc19" version="2.20-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libverto" uniqueId="fedora_19-i686-libverto-0.2.5-2.fc19" version="0.2.5-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtirpc" uniqueId="fedora_19-i686-libtirpc-0.2.3-2.fc19" version="0.2.3-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hostname" uniqueId="fedora_19-i686-hostname-3.12-4.fc19" version="3.12-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="slang" uniqueId="fedora_19-i686-slang-2.2.4-8.fc19" version="2.2.4-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses-devel" uniqueId="fedora_19-i686-ncurses-devel-5.9-11.20130511.fc19" version="5.9-11.20130511.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="zlib-devel" uniqueId="fedora_19-i686-zlib-devel-1.2.7-10.fc19" version="1.2.7-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libselinux-devel" uniqueId="fedora_19-i686-libselinux-devel-2.1.13-15.fc19" version="2.1.13-15.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="glibc-headers" uniqueId="fedora_19-i686-glibc-headers-2.17-4.fc19" version="2.17-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="krb5-devel" uniqueId="fedora_19-i686-krb5-devel-1.11.3-1.fc19" version="1.11.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gettext-libs" uniqueId="fedora_19-i686-gettext-libs-0.18.2.1-1.fc19" version="0.18.2.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cpp" uniqueId="fedora_19-i686-cpp-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="p11-kit-trust" uniqueId="fedora_19-i686-p11-kit-trust-0.18.3-1.fc19" version="0.18.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssl-libs" uniqueId="fedora_19-i686-openssl-libs-1.0.1e-4.fc19" version="1.0.1e-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libevent" uniqueId="fedora_19-i686-libevent-2.0.18-3.fc19" version="2.0.18-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="fipscheck-lib" uniqueId="fedora_19-i686-fipscheck-lib-1.3.1-3.fc19" version="1.3.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gobject-introspection" uniqueId="fedora_19-i686-gobject-introspection-1.36.0-1.fc19" version="1.36.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hesiod" uniqueId="fedora_19-i686-hesiod-3.2.1-1.fc19" version="3.2.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="keyutils" uniqueId="fedora_19-i686-keyutils-1.5.5-4.fc19" version="1.5.5-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gnutls" uniqueId="fedora_19-i686-gnutls-3.1.11-1.fc19" version="3.1.11-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tcp_wrappers" uniqueId="fedora_19-i686-tcp_wrappers-7.6-73.fc19" version="7.6-73.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="xz" uniqueId="fedora_19-i686-xz-5.1.2-4alpha.fc19" version="5.1.2-4alpha.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="acl" uniqueId="fedora_19-i686-acl-2.2.51-9.fc19" version="2.2.51-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdb-utils" uniqueId="fedora_19-i686-libdb-utils-5.3.21-11.fc19" version="5.3.21-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libatomic" uniqueId="fedora_19-i686-libatomic-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libasan" uniqueId="fedora_19-i686-libasan-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libselinux-utils" uniqueId="fedora_19-i686-libselinux-utils-2.1.13-15.fc19" version="2.1.13-15.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="procps-ng" uniqueId="fedora_19-i686-procps-ng-3.3.7-3.fc19" version="3.3.7-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pth" uniqueId="fedora_19-i686-pth-2.0.7-19.fc19" version="2.0.7-19.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="linux-atm-libs" uniqueId="fedora_19-i686-linux-atm-libs-2.5.1-7.fc19" version="2.5.1-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpciaccess" uniqueId="fedora_19-i686-libpciaccess-0.13.1-3.fc19" version="0.13.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="qrencode-libs" uniqueId="fedora_19-i686-qrencode-libs-3.4.1-1.fc19" version="3.4.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="hardlink" uniqueId="fedora_19-i686-hardlink-1.0-17.fc19" version="1.0-17.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-libs" uniqueId="fedora_19-i686-python-libs-2.7.5-1.fc19" version="2.7.5-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss-tools" uniqueId="fedora_19-i686-nss-tools-3.14.3-13.0.fc19" version="3.14.3-13.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="curl" uniqueId="fedora_19-i686-curl-7.29.0-6.fc19" version="7.29.0-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gzip" uniqueId="fedora_19-i686-gzip-1.5-4.fc19" version="1.5-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cracklib-dicts" uniqueId="fedora_19-i686-cracklib-dicts-2.8.22-3.fc19" version="2.8.22-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpm-libs" uniqueId="fedora_19-i686-rpm-libs-4.11.0.1-2.fc19" version="4.11.0.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cryptsetup-libs" uniqueId="fedora_19-i686-cryptsetup-libs-1.6.1-1.fc19" version="1.6.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmount" uniqueId="fedora_19-i686-libmount-2.23.1-3.fc19" version="2.23.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libuser" uniqueId="fedora_19-i686-libuser-0.59-1.fc19" version="0.59-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss" uniqueId="fedora_19-i686-nss-3.14.3-13.0.fc19" version="3.14.3-13.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pam" uniqueId="fedora_19-i686-pam-1.1.6-11.fc19.1" version="1.1.6-11.fc19.1" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libblkid" uniqueId="fedora_19-i686-libblkid-2.23.1-3.fc19" version="2.23.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsemanage" uniqueId="fedora_19-i686-libsemanage-2.1.10-4.fc19" version="2.1.10-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libutempter" uniqueId="fedora_19-i686-libutempter-1.1.6-2.fc19" version="1.1.6-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dbus" uniqueId="fedora_19-i686-dbus-1.6.8-5.fc19" version="1.6.8-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="policycoreutils" uniqueId="fedora_19-i686-policycoreutils-2.1.14-45.fc19" version="2.1.14-45.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="fedora-logos" uniqueId="fedora_19-i686-fedora-logos-19.0.4-2.fc19" version="19.0.4-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-decorator" uniqueId="fedora_19-i686-python-decorator-3.4.0-2.fc19" version="3.4.0-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cronie-anacron" uniqueId="fedora_19-i686-cronie-anacron-1.4.10-5.fc19" version="1.4.10-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="crontabs" uniqueId="fedora_19-i686-crontabs-1.11-5.20121102git.fc19" version="1.11-5.20121102git.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="os-prober" uniqueId="fedora_19-i686-os-prober-1.58-1.fc19" version="1.58-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="polkit-pkla-compat" uniqueId="fedora_19-i686-polkit-pkla-compat-0.1-2.fc19" version="0.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssh" uniqueId="fedora_19-i686-openssh-6.2p2-3.fc19" version="6.2p2-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dbus-python" uniqueId="fedora_19-i686-dbus-python-1.1.1-5.fc19" version="1.1.1-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dhcp-common" uniqueId="fedora_19-i686-dhcp-common-4.2.5-12.fc19" version="4.2.5-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pygpgme" uniqueId="fedora_19-i686-pygpgme-0.3-6.fc19" version="0.3-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpm-python" uniqueId="fedora_19-i686-rpm-python-4.11.0.1-2.fc19" version="4.11.0.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="device-mapper-event" uniqueId="fedora_19-i686-device-mapper-event-1.02.77-9.fc19" version="1.02.77-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dnsmasq" uniqueId="fedora_19-i686-dnsmasq-2.66-7.fc19" version="2.66-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdrm" uniqueId="fedora_19-i686-libdrm-2.4.45-1.fc19" version="2.4.45-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="grubby" uniqueId="fedora_19-i686-grubby-8.26-2.fc19" version="8.26-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="logrotate" uniqueId="fedora_19-i686-logrotate-3.8.4-1.fc19" version="3.8.4-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kpartx" uniqueId="fedora_19-i686-kpartx-0.4.9-51.fc19" version="0.4.9-51.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnfsidmap" uniqueId="fedora_19-i686-libnfsidmap-0.25-5.fc19" version="0.25-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-urlgrabber" uniqueId="fedora_19-i686-python-urlgrabber-3.9.1-27.fc19" version="3.9.1-27.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="newt-python" uniqueId="fedora_19-i686-newt-python-0.52.15-1.fc19" version="0.52.15-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pyliblzma" uniqueId="fedora_19-i686-pyliblzma-0.5.3-8.fc19" version="0.5.3-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libselinux-python" uniqueId="fedora_19-i686-libselinux-python-2.1.13-15.fc19" version="2.1.13-15.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-slip-dbus" uniqueId="fedora_19-i686-python-slip-dbus-0.4.0-1.fc19" version="0.4.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ppp" uniqueId="fedora_19-i686-ppp-2.4.5-29.fc19" version="2.4.5-29.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="sysvinit-tools" uniqueId="fedora_19-i686-sysvinit-tools-2.88-10.dsf.fc19" version="2.88-10.dsf.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssl-devel" uniqueId="fedora_19-i686-openssl-devel-1.0.1e-4.fc19" version="1.0.1e-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kernel-devel" uniqueId="fedora_19-i686-kernel-devel-3.9.5-301.fc19" version="3.9.5-301.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="initscripts" uniqueId="fedora_19-i686-initscripts-9.47-1.fc19" version="9.47-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="plymouth-scripts" uniqueId="fedora_19-i686-plymouth-scripts-0.8.9-0.2013.03.26.0.fc19" version="0.8.9-0.2013.03.26.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cyrus-sasl" uniqueId="fedora_19-i686-cyrus-sasl-2.1.26-8.fc19" version="2.1.26-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="setup" uniqueId="fedora_19-i686-setup-2.8.71-1.fc19" version="2.8.71-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="avahi" uniqueId="fedora_19-i686-avahi-0.6.31-11.fc19" version="0.6.31-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="basesystem" uniqueId="fedora_19-i686-basesystem-10.0-8.fc19" version="10.0-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ebtables" uniqueId="fedora_19-i686-ebtables-2.0.10-8.fc19" version="2.0.10-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tzdata" uniqueId="fedora_19-i686-tzdata-2013c-1.fc19" version="2013c-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="firewalld" uniqueId="fedora_19-i686-firewalld-0.3.3-2.fc19" version="0.3.3-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kbd-misc" uniqueId="fedora_19-i686-kbd-misc-1.15.5-6.fc19" version="1.15.5-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="NetworkManager" uniqueId="fedora_19-i686-NetworkManager-0.9.8.2-2.fc19" version="0.9.8.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="fedora-release" uniqueId="fedora_19-i686-fedora-release-19-2" version="19-2" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kbd" uniqueId="fedora_19-i686-kbd-1.15.5-6.fc19" version="1.15.5-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses-base" uniqueId="fedora_19-i686-ncurses-base-5.9-11.20130511.fc19" version="5.9-11.20130511.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rsyslog" uniqueId="fedora_19-i686-rsyslog-7.2.6-1.fc19" version="7.2.6-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgcc" uniqueId="fedora_19-i686-libgcc-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gcc" uniqueId="fedora_19-i686-gcc-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="glibc-common" uniqueId="fedora_19-i686-glibc-common-2.17-4.fc19" version="2.17-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssh-server" uniqueId="fedora_19-i686-openssh-server-6.2p2-3.fc19" version="6.2p2-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="glibc" uniqueId="fedora_19-i686-glibc-2.17-4.fc19" version="2.17-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="biosdevname" uniqueId="fedora_19-i686-biosdevname-0.4.1-4.fc19" version="0.4.1-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses-libs" uniqueId="fedora_19-i686-ncurses-libs-5.9-11.20130511.fc19" version="5.9-11.20130511.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="net-tools" uniqueId="fedora_19-i686-net-tools-2.0-0.6.20130109git.fc19" version="2.0-0.6.20130109git.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsepol" uniqueId="fedora_19-i686-libsepol-2.1.9-1.fc19" version="2.1.9-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="e2fsprogs" uniqueId="fedora_19-i686-e2fsprogs-1.42.7-2.fc19" version="1.42.7-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcap" uniqueId="fedora_19-i686-libcap-2.22-6.fc19" version="2.22-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="passwd" uniqueId="fedora_19-i686-passwd-0.78.99-4.fc19" version="0.78.99-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libselinux" uniqueId="fedora_19-i686-libselinux-2.1.13-15.fc19" version="2.1.13-15.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="wget" uniqueId="fedora_19-i686-wget-1.14-5.fc19" version="1.14-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="info" uniqueId="fedora_19-i686-info-5.1-1.fc19" version="5.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="tar" uniqueId="fedora_19-i686-tar-1.26-24.fc19" version="1.26-24.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="audit-libs" uniqueId="fedora_19-i686-audit-libs-2.3.1-2.fc19" version="2.3.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-setuptools" uniqueId="fedora_19-i686-python-setuptools-0.6.49-1.fc19" version="0.6.49-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libacl" uniqueId="fedora_19-i686-libacl-2.2.51-9.fc19" version="2.2.51-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Error" uniqueId="fedora_19-i686-perl-Error-0.17020-1.fc19" version="0.17020-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="chkconfig" uniqueId="fedora_19-i686-chkconfig-1.3.60-3.fc19" version="1.3.60-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rsync" uniqueId="fedora_19-i686-rsync-3.0.9-12.fc19" version="3.0.9-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dbus-libs" uniqueId="fedora_19-i686-dbus-libs-1.6.8-5.fc19" version="1.6.8-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="git" uniqueId="fedora_19-i686-git-1.8.3.1-1.fc19" version="1.8.3.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nspr" uniqueId="fedora_19-i686-nspr-4.9.6-1.fc19" version="4.9.6-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-chardet" uniqueId="fedora_19-i686-python-chardet-2.0.1-6.fc19" version="2.0.1-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss-util" uniqueId="fedora_19-i686-nss-util-3.14.3-1.fc19" version="3.14.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="yum-utils" uniqueId="fedora_19-i686-yum-utils-1.1.31-18.fc19" version="1.1.31-18.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bzip2-libs" uniqueId="fedora_19-i686-bzip2-libs-1.0.6-8.fc19" version="1.0.6-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="readline" uniqueId="fedora_19-i686-readline-6.2-6.fc19" version="6.2-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgpg-error" uniqueId="fedora_19-i686-libgpg-error-1.11-1.fc19" version="1.11-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="keyutils-libs" uniqueId="fedora_19-i686-keyutils-libs-1.5.5-4.fc19" version="1.5.5-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="findutils" uniqueId="fedora_19-i686-findutils-4.5.11-1.fc19" version="4.5.11-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libidn" uniqueId="fedora_19-i686-libidn-1.26-2.fc19" version="1.26-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lua" uniqueId="fedora_19-i686-lua-5.1.4-12.fc19" version="5.1.4-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libffi" uniqueId="fedora_19-i686-libffi-3.0.13-4.fc19" version="3.0.13-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="glib2" uniqueId="fedora_19-i686-glib2-2.36.3-2.fc19" version="2.36.3-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="elfutils-libelf" uniqueId="fedora_19-i686-elfutils-libelf-0.155-5.fc19" version="0.155-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mpfr" uniqueId="fedora_19-i686-mpfr-3.1.1-2.fc19" version="3.1.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgomp" uniqueId="fedora_19-i686-libgomp-4.8.1-1.fc19" version="4.8.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="file-libs" uniqueId="fedora_19-i686-file-libs-5.11-9.fc19" version="5.11-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcap-ng" uniqueId="fedora_19-i686-libcap-ng-0.7.3-3.fc19" version="0.7.3-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gdbm" uniqueId="fedora_19-i686-gdbm-1.10-6.fc19" version="1.10-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Pod-Escapes" uniqueId="fedora_19-i686-perl-Pod-Escapes-1.04-264.fc19" version="1.04-264.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-macros" uniqueId="fedora_19-i686-perl-macros-5.16.3-264.fc19" version="5.16.3-264.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Scalar-List-Utils" uniqueId="fedora_19-i686-perl-Scalar-List-Utils-1.27-246.fc19" version="1.27-246.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-PathTools" uniqueId="fedora_19-i686-perl-PathTools-3.40-1.fc19" version="3.40-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Socket" uniqueId="fedora_19-i686-perl-Socket-2.009-2.fc19" version="2.009-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="perl-Pod-Simple" uniqueId="fedora_19-i686-perl-Pod-Simple-3.20-264.fc19" version="3.20-264.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libtasn1" uniqueId="fedora_19-i686-libtasn1-3.3-1.fc19" version="3.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libee" uniqueId="fedora_19-i686-libee-0.4.1-4.fc19" version="0.4.1-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmpc" uniqueId="fedora_19-i686-libmpc-1.0.1-1.fc19" version="1.0.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libassuan" uniqueId="fedora_19-i686-libassuan-2.0.3-5.fc19" version="2.0.3-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kmod-libs" uniqueId="fedora_19-i686-kmod-libs-13-2.fc19" version="13-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="e2fsprogs-libs" uniqueId="fedora_19-i686-e2fsprogs-libs-1.42.7-2.fc19" version="1.42.7-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libunistring" uniqueId="fedora_19-i686-libunistring-0.9.3-7.fc19" version="0.9.3-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="krb5-libs" uniqueId="fedora_19-i686-krb5-libs-1.11.3-1.fc19" version="1.11.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libdaemon" uniqueId="fedora_19-i686-libdaemon-0.14-5.fc19" version="0.14-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libnl3" uniqueId="fedora_19-i686-libnl3-3.2.21-1.fc19" version="3.2.21-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libverto-devel" uniqueId="fedora_19-i686-libverto-devel-0.2.5-2.fc19" version="0.2.5-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcom_err-devel" uniqueId="fedora_19-i686-libcom_err-devel-1.42.7-2.fc19" version="1.42.7-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libsepol-devel" uniqueId="fedora_19-i686-libsepol-devel-2.1.9-1.fc19" version="2.1.9-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="keyutils-libs-devel" uniqueId="fedora_19-i686-keyutils-libs-devel-1.5.5-4.fc19" version="1.5.5-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="glibc-devel" uniqueId="fedora_19-i686-glibc-devel-2.17-4.fc19" version="2.17-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="newt" uniqueId="fedora_19-i686-newt-0.52.15-1.fc19" version="0.52.15-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="less" uniqueId="fedora_19-i686-less-458-3.fc19" version="458-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="liblognorm" uniqueId="fedora_19-i686-liblognorm-0.3.5-1.fc19" version="0.3.5-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ca-certificates" uniqueId="fedora_19-i686-ca-certificates-2012.87-10.2.fc19" version="2012.87-10.2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libssh2" uniqueId="fedora_19-i686-libssh2-1.4.3-4.fc19" version="1.4.3-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="bind-libs-lite" uniqueId="fedora_19-i686-bind-libs-lite-9.9.3-3.P1.fc19" version="9.9.3-3.P1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="fipscheck" uniqueId="fedora_19-i686-fipscheck-1.3.1-3.fc19" version="1.3.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss-softokn" uniqueId="fedora_19-i686-nss-softokn-3.14.3-1.fc19" version="3.14.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="device-mapper-persistent-data" uniqueId="fedora_19-i686-device-mapper-persistent-data-0.1.4-3.fc19" version="0.1.4-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nettle" uniqueId="fedora_19-i686-nettle-2.6-2.fc19" version="2.6-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libmicrohttpd" uniqueId="fedora_19-i686-libmicrohttpd-0.9.27-1.fc19" version="0.9.27-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="mozjs17" uniqueId="fedora_19-i686-mozjs17-17.0.0-7.fc19" version="17.0.0-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pinentry" uniqueId="fedora_19-i686-pinentry-0.8.1-10.fc19" version="0.8.1-10.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="vim-minimal" uniqueId="fedora_19-i686-vim-minimal-7.3.944-1.fc19" version="7.3.944-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libss" uniqueId="fedora_19-i686-libss-1.42.7-2.fc19" version="1.42.7-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="diffutils" uniqueId="fedora_19-i686-diffutils-3.3-1.fc19" version="3.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="make" uniqueId="fedora_19-i686-make-3.82-15.fc19" version="3.82-15.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="procmail" uniqueId="fedora_19-i686-procmail-3.22-32.fc19" version="3.22-32.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ncurses" uniqueId="fedora_19-i686-ncurses-5.9-11.20130511.fc19" version="5.9-11.20130511.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libedit" uniqueId="fedora_19-i686-libedit-3.0-10.20121213cvs.fc19" version="3.0-10.20121213cvs.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="plymouth-core-libs" uniqueId="fedora_19-i686-plymouth-core-libs-0.8.9-0.2013.03.26.0.fc19" version="0.8.9-0.2013.03.26.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iproute" uniqueId="fedora_19-i686-iproute-3.9.0-1.fc19" version="3.9.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pciutils-libs" uniqueId="fedora_19-i686-pciutils-libs-3.2.0-2.fc19" version="3.2.0-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpipeline" uniqueId="fedora_19-i686-libpipeline-1.2.3-1.fc19" version="1.2.3-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="ustr" uniqueId="fedora_19-i686-ustr-1.0.4-14.fc19" version="1.0.4-14.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python" uniqueId="fedora_19-i686-python-2.7.5-1.fc19" version="2.7.5-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libcurl" uniqueId="fedora_19-i686-libcurl-7.29.0-6.fc19" version="7.29.0-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="device-mapper" uniqueId="fedora_19-i686-device-mapper-1.02.77-9.fc19" version="1.02.77-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cracklib" uniqueId="fedora_19-i686-cracklib-2.8.22-3.fc19" version="2.8.22-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openldap" uniqueId="fedora_19-i686-openldap-2.4.35-4.fc19" version="2.4.35-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="device-mapper-libs" uniqueId="fedora_19-i686-device-mapper-libs-1.02.77-9.fc19" version="1.02.77-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpwquality" uniqueId="fedora_19-i686-libpwquality-1.2.1-2.fc19" version="1.2.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="systemd-sysv" uniqueId="fedora_19-i686-systemd-sysv-204-8.fc19" version="204-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpm" uniqueId="fedora_19-i686-rpm-4.11.0.1-2.fc19" version="4.11.0.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="coreutils" uniqueId="fedora_19-i686-coreutils-8.21-11.fc19" version="8.21-11.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="systemd-libs" uniqueId="fedora_19-i686-systemd-libs-204-8.fc19" version="204-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="nss-sysinit" uniqueId="fedora_19-i686-nss-sysinit-3.14.3-13.0.fc19" version="3.14.3-13.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="shadow-utils" uniqueId="fedora_19-i686-shadow-utils-4.1.5.1-5.fc19" version="4.1.5.1-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="util-linux" uniqueId="fedora_19-i686-util-linux-2.23.1-3.fc19" version="2.23.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="systemd" uniqueId="fedora_19-i686-systemd-204-8.fc19" version="204-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="selinux-policy" uniqueId="fedora_19-i686-selinux-policy-3.12.1-54.fc19" version="3.12.1-54.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dhcp-libs" uniqueId="fedora_19-i686-dhcp-libs-4.2.5-12.fc19" version="4.2.5-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="device-mapper-event-libs" uniqueId="fedora_19-i686-device-mapper-event-libs-1.02.77-9.fc19" version="1.02.77-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="cronie" uniqueId="fedora_19-i686-cronie-1.4.10-5.fc19" version="1.4.10-5.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="iputils" uniqueId="fedora_19-i686-iputils-20121221-2.fc19" version="20121221-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="polkit" uniqueId="fedora_19-i686-polkit-0.111-2.fc19" version="0.111-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libgudev1" uniqueId="fedora_19-i686-libgudev1-204-8.fc19" version="204-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gnupg2" uniqueId="fedora_19-i686-gnupg2-2.0.19-8.fc19" version="2.0.19-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gettext" uniqueId="fedora_19-i686-gettext-0.18.2.1-1.fc19" version="0.18.2.1-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-iniparse" uniqueId="fedora_19-i686-python-iniparse-0.4-7.fc19" version="0.4-7.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="gpgme" uniqueId="fedora_19-i686-gpgme-1.3.2-3.fc19" version="1.3.2-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpm-build-libs" uniqueId="fedora_19-i686-rpm-build-libs-4.11.0.1-2.fc19" version="4.11.0.1-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="NetworkManager-glib" uniqueId="fedora_19-i686-NetworkManager-glib-0.9.8.2-2.fc19" version="0.9.8.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="lvm2-libs" uniqueId="fedora_19-i686-lvm2-libs-2.02.98-9.fc19" version="2.02.98-9.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="rpcbind" uniqueId="fedora_19-i686-rpcbind-0.2.0-21.fc19" version="0.2.0-21.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="wpa_supplicant" uniqueId="fedora_19-i686-wpa_supplicant-2.0-3.fc19" version="2.0-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="binutils" uniqueId="fedora_19-i686-binutils-2.23.52.0.1-8.fc19" version="2.23.52.0.1-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="openssl" uniqueId="fedora_19-i686-openssl-1.0.1e-4.fc19" version="1.0.1e-4.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dracut" uniqueId="fedora_19-i686-dracut-029-1.fc19" version="029-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-pycurl" uniqueId="fedora_19-i686-python-pycurl-7.19.0-15.1.fc19" version="7.19.0-15.1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pyxattr" uniqueId="fedora_19-i686-pyxattr-0.5.1-3.fc19" version="0.5.1-3.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="yum-metadata-parser" uniqueId="fedora_19-i686-yum-metadata-parser-1.1.4-8.fc19" version="1.1.4-8.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="pygobject3-base" uniqueId="fedora_19-i686-pygobject3-base-3.8.2-2.fc19" version="3.8.2-2.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="python-slip" uniqueId="fedora_19-i686-python-slip-0.4.0-1.fc19" version="0.4.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="libpcap" uniqueId="fedora_19-i686-libpcap-1.4.0-1.fc19" version="1.4.0-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="json-c" uniqueId="fedora_19-i686-json-c-0.11-1.fc19" version="0.11-1.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="yum" uniqueId="fedora_19-i686-yum-3.4.3-99.fc19" version="3.4.3-99.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="selinux-policy-targeted" uniqueId="fedora_19-i686-selinux-policy-targeted-3.12.1-54.fc19" version="3.12.1-54.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="readline-devel" uniqueId="fedora_19-i686-readline-devel-6.2-6.fc19" version="6.2-6.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="kernel-PAE-devel" uniqueId="fedora_19-i686-kernel-PAE-devel-3.9.5-301.fc19" version="3.9.5-301.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="dhclient" uniqueId="fedora_19-i686-dhclient-4.2.5-12.fc19" version="4.2.5-12.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>
 
 <?xml version="1.0" encoding="UTF-8"?>
 <SoftwareIdentity name="plymouth" uniqueId="fedora_19-i686-plymouth-0.8.9-0.2013.03.26.0.fc19" version="0.8.9-0.2013.03.26.0.fc19" versionScheme="alphanumeric" xmlns="http://standards.iso.org/iso/19770/-2/2014/schema.xsd">
-  <Entity name="strongSwan" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
+  <Entity name="strongSwan Project" regid="regid.2004-03.org.strongswan" role="tagcreator"/>
 </SoftwareIdentity>


### PR DESCRIPTION
Fixes according to e-mail by A. Steffen:

1) default entity-name "strongSwan Project"
2) change to --help text:  entity-name can contain spaces if argument is put in double quotes
