### PR TITLE
Illegal chars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,10 +26,10 @@ pacman.
 
 Usage
 =====
-The tool provides 2 subcommands to generate SWID tags or Software IDs
 
-Generate SWID tags:
-::
+The tool provides 2 subcommands to generate SWID tags or Software IDs.
+
+Generate SWID tags::
 
     usage: swid_generator swid [-h] [--env {auto,dpkg,pacman,rpm}]
                                [--doc-separator DOCUMENT_SEPARATOR] [--regid REGID]
@@ -73,8 +73,7 @@ Generate SWID tags:
                             managed environment. If no matching package is found, the output
                             is empty and the exit code is set to 1.
 
-Generate Software IDs:
-::
+Generate Software IDs::
 
     usage: swid_generator software-id [-h] [--env {auto,dpkg,pacman,rpm}]
                                       [--doc-separator DOCUMENT_SEPARATOR] [--regid REGID]
@@ -108,7 +107,14 @@ If the application fails somehow, an exit code is set appropriately:
 The exit code can be shown with::
 
     $ echo $?
-    
+
+
+Reserved Characters
+-------------------
+
+URI reserved characters (``:/?#[]@!$&'()*+,;=``) in a package version or name
+are replaced with a tilde (``~``) sign.
+
 
 Installation
 ============

--- a/swid_generator/generators/softwareid_generator.py
+++ b/swid_generator/generators/softwareid_generator.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, division, absolute_import, unicode_literals
 
+from .utils import create_unique_id, create_software_id
+
 
 def create_software_ids(env, regid):
     pkg_info = env.get_package_list()
-    os_info = env.get_os_string()
+    os_string = env.get_os_string()
+    architecture = env.get_architecture()
 
     for pi in pkg_info:
-        software_id = '{regid}_{os_info}-{architecture}-{pi.package}-{pi.version}' \
-            .format(regid=regid,
-                    os_info=os_info, pi=pi,
-                    architecture=env.get_architecture())
+        unique_id = create_unique_id(pi, os_string, architecture)
+        software_id = create_software_id(regid, unique_id)
         yield software_id

--- a/swid_generator/generators/swid_generator.py
+++ b/swid_generator/generators/swid_generator.py
@@ -3,6 +3,8 @@ from __future__ import print_function, division, absolute_import, unicode_litera
 
 from xml.etree import cElementTree as ET
 
+from .utils import create_unique_id, create_software_id
+
 
 ROLE = 'tagcreator'
 VERSION_SCHEME = 'alphanumeric'
@@ -20,18 +22,6 @@ def _create_payload_tag(package_info):
     return payload
 
 
-def _create_unique_id(os_info, package_info, architecture):
-    unique_id_format = '{os_info}-{architecture}-{pi.package}-{pi.version}'
-    return unique_id_format.format(os_info=os_info,
-                                   pi=package_info,
-                                   architecture=architecture)
-
-
-def _create_software_id(os_info, package_info, regid, architecture):
-    return '{regid}_{uniqueID}'.format(
-        regid=regid, uniqueID=_create_unique_id(os_info, package_info, architecture))
-
-
 def all_matcher(ctx):
     return True
 
@@ -41,12 +31,11 @@ def package_name_matcher(ctx, value):
 
 
 def software_id_matcher(ctx, value):
-    software_id = _create_software_id(
-        ctx['environment'].get_os_string(),
-        ctx['package_info'],
-        ctx['regid'],
-        ctx['environment'].get_architecture())
-
+    env = ctx['environment']
+    os_string = env.get_os_string()
+    architecture = env.get_architecture()
+    unique_id = create_unique_id(ctx['package_info'], os_string, architecture)
+    software_id = create_software_id(ctx['regid'], unique_id)
     return software_id == value
 
 
@@ -73,8 +62,9 @@ def create_swid_tags(environment, entity_name, regid, full=False, matcher=all_ma
         are all bytestrings, using UTF-8 encoding.
 
     """
-    os_info = environment.get_os_string()
+    os_string = environment.get_os_string()
     pkg_info = environment.get_package_list()
+    architecture = environment.get_architecture()
 
     for pi in pkg_info:
 
@@ -91,7 +81,7 @@ def create_swid_tags(environment, entity_name, regid, full=False, matcher=all_ma
         software_identity = ET.Element('SoftwareIdentity')
         software_identity.set('xmlns', XMLNS)
         software_identity.set('name', pi.package)
-        software_identity.set('uniqueId', _create_unique_id(os_info, pi, environment.get_architecture()))
+        software_identity.set('uniqueId', create_unique_id(pi, os_string, architecture))
 
         software_identity.set('version', pi.version)
         software_identity.set('versionScheme', VERSION_SCHEME)

--- a/swid_generator/generators/utils.py
+++ b/swid_generator/generators/utils.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+import re
+
+
+uri_reserved_chars_re = re.compile(r'[:\/?#\[\]@!$&\'()*+,;=]')
+
+
+def create_unique_id(package_info, os_string, architecture):
+    """
+    Create a Unique-ID.
+
+    Args:
+        package_info (PackageInfo):
+            A ``PackageInfo`` instance.
+        os_string (str):
+            An string representing the current distribution,
+            e.g. ``debian_7.4`` or ``fedora_19``.
+        architecture (str):
+            The system architecture, e.g. ``x86_64`` or ``i386``.
+
+    Returns:
+        The Unique-ID string.
+
+    """
+    unique_id_format = '{os_string}-{architecture}-{pi.package}-{pi.version}'
+    unique_id = unique_id_format.format(os_string=os_string,
+                                        architecture=architecture,
+                                        pi=package_info)
+    return uri_reserved_chars_re.sub('~', unique_id)
+
+
+def create_software_id(regid, unique_id):
+    """
+    Create a Software-ID by joining the Regid and the Unique-ID with an underscore.
+
+    Args:
+        regid (str):
+            The Regid string.
+        unique_id (str):
+            The Unique-ID string.
+
+    Returns:
+        The Software-ID string.
+
+    """
+    return '{regid}_{unique_id}'.format(regid=regid, unique_id=unique_id)

--- a/tests/test_generator_utils.py
+++ b/tests/test_generator_utils.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+from swid_generator.package_info import PackageInfo
+from swid_generator.generators import utils
+
+
+def test_valid_unique_id():
+    pi = PackageInfo(package='swid_generator', version='0.1.2')
+    os_string = 'debian_7.4'
+    architecture = 'x86_64'
+    unique_id = utils.create_unique_id(pi, os_string, architecture)
+    assert unique_id == 'debian_7.4-x86_64-swid_generator-0.1.2'
+
+
+def test_reserved_unique_id():
+    """
+    Test a unique ID with a version that contains reserved characters.
+    """
+    pi = PackageInfo(package='ntp', version="1:4/2?6#p[3]+dfsg-1!ubuntu@3.1$&'()*,;=")
+    os_string = 'debian_7.4'
+    architecture = 'i686'
+    unique_id = utils.create_unique_id(pi, os_string, architecture)
+    assert unique_id == 'debian_7.4-i686-ntp-1~4~2~6~p~3~~dfsg-1~ubuntu~3.1~~~~~~~~~'
+
+
+def test_software_id():
+    regid = 'regid.2004-03.org.strongswan'
+    unique_id = 'debian_7.4-x86_64-swid_generator-0.1.2'
+    software_id = utils.create_software_id(regid, unique_id)
+    assert software_id == 'regid.2004-03.org.strongswan_debian_7.4-x86_64-swid_generator-0.1.2'


### PR DESCRIPTION
Replace URI reserved chars with a tilde (`~`).

This pull request is based on #30, merge that first. Only the latest commit is relevant to this PR.

Please review, @cfaessler.
