### PR TITLE
Python3: README.rst should be openned as utf-8.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 from swid_generator import meta
 
-readme = open('README.rst').read()
+readme = open('README.rst', encoding='utf-8').read()
 
 setup(name='swid_generator',
       version=meta.version,


### PR DESCRIPTION
Addressing:
$ /usr/bin/python3 setup.py install
Traceback (most recent call last):
  File "setup.py", line 7, in <module>
    readme = open('README.rst').read()
  File "/usr/lib64/python3.3/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position
8545: ordinal not in range(128)
