### PR TITLE
NIST.IR.8060 GEN-2 requires xml:lang.

### DIFF
--- a/swid_generator/argparser.py
+++ b/swid_generator/argparser.py
@@ -72,6 +72,10 @@ class MainArgumentParser(object):
         swid_parser.add_argument('--pkcs12-pwd', dest='password',
                                  help='If the PKCS#12 file is password protected, '
                                       'the password needs to be provided.')
+        swid_parser.add_argument('--lang', dest='xml_lang', type=str,
+                                 default=str(settings.DEFAULT_XML_LANG),
+                                 help='Value of xml:lang attribute. '
+                                      'Default is "%s".' % settings.DEFAULT_XML_LANG)
 
         swid_parser.set_defaults(matcher=all_matcher)
 

--- a/swid_generator/generators/swid_generator.py
+++ b/swid_generator/generators/swid_generator.py
@@ -63,6 +63,7 @@ def create_software_identity_element(ctx, from_package_file=False, from_folder=F
     software_identity.set('xmlns', XMLNS)
     software_identity.set('xmlns:n8060', N8060)
     software_identity.set('name', ctx['package_info'].package)
+    software_identity.set('xml:lang', ctx['xml_lang'])
     software_identity.set('tagId', create_unique_id(ctx['package_info'], ctx['os_string'], ctx['architecture']))
     software_identity.set('version', ctx['package_info'].version)
     software_identity.set('versionScheme', VERSION_SCHEME)
@@ -109,7 +110,7 @@ def create_software_identity_element(ctx, from_package_file=False, from_folder=F
 
 def create_swid_tags(environment, entity_name, regid, os_string=None, architecture=None, hash_algorithms='sha256',
                      full=False, matcher=all_matcher, hierarchic=False, file_path=None, evidence_path=None,
-                     name=None, version=None, new_root_path=None, pkcs12_file=None):
+                     name=None, version=None, new_root_path=None, pkcs12_file=None, xml_lang=None):
     """
     Return SWID tags as utf8-encoded xml bytestrings for all available
     packages.
@@ -127,6 +128,7 @@ def create_swid_tags(environment, entity_name, regid, os_string=None, architectu
     :param hash_algorithms: Comma separated list of the hash algorithms to include in the SWID tag,
     :param full: Whether to include file payload. Default is False.
     :param matcher: A function that defines whether to return a tag or not. Default is a function that returns ``True`` for all tags.
+    :param xml_lang: xml:lang attribute value. Default en-US.
 
     Returns:
         A generator object for all available SWID XML strings. The XML strings
@@ -145,7 +147,8 @@ def create_swid_tags(environment, entity_name, regid, os_string=None, architectu
         'hierarchic': hierarchic,
         'file_path': file_path,
         'evidence_path': evidence_path,
-        'new_root_path': new_root_path
+        'new_root_path': new_root_path,
+        'xml_lang': xml_lang
     }
 
     if os_string is None:

--- a/swid_generator/main.py
+++ b/swid_generator/main.py
@@ -83,7 +83,8 @@ def main():
             'new_root_path': options.new_root,
             'name': options.name,
             'version': options.version,
-            'pkcs12_file': options.pkcs12
+            'pkcs12_file': options.pkcs12,
+            'xml_lang': options.xml_lang
         }
 
         signature_args = {

--- a/swid_generator/settings.py
+++ b/swid_generator/settings.py
@@ -1,3 +1,4 @@
 DEFAULT_REGID = u'strongswan.org'
 DEFAULT_ENTITY_NAME = u'strongSwan Project'
 DEFAULT_HASH_ALGORITHM = u'sha256'
+DEFAULT_XML_LANG = u'en-US'

--- a/tests/test_swid_generator.py
+++ b/tests/test_swid_generator.py
@@ -7,7 +7,7 @@ from xml.etree import cElementTree as ET
 
 from swid_generator.generators import swid_generator
 from swid_generator.package_info import PackageInfo
-from swid_generator.settings import DEFAULT_REGID, DEFAULT_ENTITY_NAME
+from swid_generator.settings import DEFAULT_REGID, DEFAULT_ENTITY_NAME, DEFAULT_XML_LANG
 from swid_generator.environments.common import CommonEnvironment
 from swid_generator.generators.swid_generator import _create_flat_payload_tag, _create_hierarchic_payload_tag
 from swid_generator.generators.swid_generator import software_id_matcher, package_name_matcher
@@ -120,7 +120,8 @@ class SwidGeneratorTests(unittest.TestCase):
         kwargs = {
             'environment': env,
             'entity_name': DEFAULT_ENTITY_NAME,
-            'regid': DEFAULT_REGID
+            'regid': DEFAULT_REGID,
+            'xml_lang': DEFAULT_XML_LANG
         }
         self.swid_tag_generator = partial(swid_generator.create_swid_tags, **kwargs)
 


### PR DESCRIPTION
Default it to en-US, add parameter `--lang` to change it.