### PR TITLE
NIST.IR.8060 GEN-22 to 24 require three n8060 attributes.

### DIFF
--- a/swid_generator/generators/content_creator.py
+++ b/swid_generator/generators/content_creator.py
@@ -41,6 +41,10 @@ def create_flat_content_tag(root_element, package_info, hash_algorithms):
     last_full_pathname = ""
     last_directory_tag = ""
 
+    root_element.set('n8060:pathSeparator', '/')
+    root_element.set('n8060:envVarPrefix', '$')
+    root_element.set('n8060:envVarSuffix', '')
+
     if len(package_info.files) > 0:
         package_info.files = _sort_files(package_info.files)
 
@@ -76,6 +80,10 @@ def create_flat_content_tag(root_element, package_info, hash_algorithms):
 
 
 def create_hierarchic_content_tag(root_element, package_info, hash_algorithms):
+    root_element.set('n8060:pathSeparator', '/')
+    root_element.set('n8060:envVarPrefix', '$')
+    root_element.set('n8060:envVarSuffix', '')
+
     for file in package_info.files:
         splitted_location = file.location.split('/')
         splitted_location.append(file.name)


### PR DESCRIPTION
Swidval 0.5.0 furthermore requires all but `envVarSuffix` to be nonempty.
Using reasonable Linux defaults.