### PR TITLE
NIST.IR.8060 PRI-13 requires additional attributes for Meta

### DIFF
--- a/swid_generator/generators/swid_generator.py
+++ b/swid_generator/generators/swid_generator.py
@@ -81,6 +81,9 @@ def create_software_identity_element(ctx, from_package_file=False, from_folder=F
 
     product_meta = ET.SubElement(software_identity, 'Meta')
     product_meta.set('product', create_system_id(ctx['os_string'], ctx['architecture']))
+    product_meta.set('colloquialVersion', "")
+    product_meta.set('revision', "")
+    product_meta.set('edition', "")
 
     if ctx['full']:
 


### PR DESCRIPTION
Addressing swidval errors
```
ERROR PRI-13-3: The <Meta> @colloquialVersion attribute was not provided.
ERROR PRI-13-4: The <Meta> @revision attribute was not provided.
ERROR PRI-13-5: The <Meta> @edition attribute was not provided.
```
Leaving the attribute values empty seems enough to make `swidval` happy.
We could put the name (sans version) to `product` and then have version in `colloquialVersion`, to turn
```
  <Meta colloquialVersion="" edition="" product="Fedora 28 i686" revision=""/>
```
into (say)
```
  <Meta colloquialVersion="28" edition="" product="Fedora" revision=""/>
```
But I plan to add option to use `Meta` for information about the package, not about the distribution.