### PR TITLE
Distinguish package architectures, in tagId and version

### DIFF
--- a/swid_generator/argparser.py
+++ b/swid_generator/argparser.py
@@ -54,6 +54,8 @@ class MainArgumentParser(object):
                                  default=None,
                                  help='The HW architecture used in the tagId attribute. '
                                       'Default is derived from the HW architecture of the local host.')
+        swid_parser.add_argument('--dpkg-include-package-arch', action='store_true', default=False,
+                                 help='Include package architecture in tagId and version, for dpkg.')
         swid_parser.add_argument('--schema-location', action='store_true', default=False,
                                  help='Add xsi:schemaLocation attribute with schema URIs to validate the '
                                       'resulting XML documents.')

--- a/swid_generator/environments/dpkg_environment.py
+++ b/swid_generator/environments/dpkg_environment.py
@@ -49,7 +49,7 @@ class DpkgEnvironment(CommonEnvironment):
 
         """
         result = []
-        command_args = [cls.executable_query, '-W', '-f=${Package}\\n${Version}\\n${Status}\\n${conffiles}\\t']
+        command_args = [cls.executable_query, '-W', '-f=${Package}\\n${Version}.${Architecture}\\n${Status}\\n${conffiles}\\t']
 
         command_output = CM.run_command_check_output(command_args)
 
@@ -230,11 +230,13 @@ class DpkgEnvironment(CommonEnvironment):
         """
         command_args_packagename = [cls.executable, '-f', file_path, 'Package']
         command_args_version = [cls.executable, '-f', file_path, 'Version']
+        command_args_arch = [cls.executable, '-f', file_path, 'Architecture']
         package_name = CM.run_command_check_output(command_args_packagename)
         package_version = CM.run_command_check_output(command_args_version)
+        package_arch = CM.run_command_check_output(command_args_arch)
 
         package_info = PackageInfo()
         package_info.package = package_name.strip()
-        package_info.version = package_version.strip()
+        package_info.version = package_version.strip() + '.' + package_arch.strip()
 
         return package_info

--- a/swid_generator/environments/pacman_environment.py
+++ b/swid_generator/environments/pacman_environment.py
@@ -24,7 +24,7 @@ class PacmanEnvironment(CommonEnvironment):
     ]
 
     @classmethod
-    def get_package_list(cls):
+    def get_package_list(cls, ctx=None):
         """
         Get list of installed packages.
 
@@ -118,11 +118,12 @@ class PacmanEnvironment(CommonEnvironment):
         return all_files
 
     @classmethod
-    def get_packageinfo_from_packagefile(cls, file_path):
+    def get_packageinfo_from_packagefile(cls, file_path, ctx=None):
         """
         Extract the Package-Name and the Package-Version from the Pacman-Package.
 
         :param file_path: Path to the Pacman-Package
+        :param ctx: ignored
         :return: A PackageInfo()-Object with Package-Version and Package-Name.
         """
         command_args_packageinfo = [cls.executable, '--query', '--file', file_path]

--- a/swid_generator/environments/rpm_environment.py
+++ b/swid_generator/environments/rpm_environment.py
@@ -32,7 +32,7 @@ class RpmEnvironment(CommonEnvironment):
     ]
 
     @classmethod
-    def get_package_list(cls):
+    def get_package_list(cls, ctx=None):
         """
         Get list of installed packages.
 
@@ -145,11 +145,12 @@ class RpmEnvironment(CommonEnvironment):
         return all_file_info
 
     @classmethod
-    def get_packageinfo_from_packagefile(cls, file_path):
+    def get_packageinfo_from_packagefile(cls, file_path, ctx=None):
         """
         Extract the Package-Name and the Package-Version from the Debian-Package.
 
         :param file_path: Path to the Rpm-Package
+        :param ctx: ignored
         :return: A PackageInfo()-Object with Package-Version and Package-Name.
         """
         command_args_package_name = [cls.executable, "--query", "--package", "--queryformat", "%{name}", file_path]

--- a/swid_generator/environments/rpm_environment.py
+++ b/swid_generator/environments/rpm_environment.py
@@ -42,7 +42,7 @@ class RpmEnvironment(CommonEnvironment):
         """
 
         command_args_package_list = [cls.executable, '-qa', '--queryformat',
-                                     '\t%{name} %{version}-%{release}']
+                                     '\t%{name} %{version}-%{release}.%{arch}']
         package_list_output = CM.run_command_check_output(command_args_package_list)
 
         line_list = package_list_output.split('\t')
@@ -153,7 +153,7 @@ class RpmEnvironment(CommonEnvironment):
         :return: A PackageInfo()-Object with Package-Version and Package-Name.
         """
         command_args_package_name = [cls.executable, "--query", "--package", "--queryformat", "%{name}", file_path]
-        command_args_package_version = [cls.executable, "--query", "--package", "--queryformat", "%{version}-%{release}", file_path]
+        command_args_package_version = [cls.executable, "--query", "--package", "--queryformat", "%{version}-%{release}.%{arch}", file_path]
 
         package_name_output = CM.run_command_check_output(command_args_package_name)
         package_version_output = CM.run_command_check_output(command_args_package_version)

--- a/swid_generator/generators/swid_generator.py
+++ b/swid_generator/generators/swid_generator.py
@@ -116,7 +116,8 @@ def create_software_identity_element(ctx, from_package_file=False, from_folder=F
 
 def create_swid_tags(environment, entity_name, regid, os_string=None, architecture=None, hash_algorithms='sha256',
                      full=False, matcher=all_matcher, hierarchic=False, file_path=None, evidence_path=None,
-                     name=None, version=None, new_root_path=None, pkcs12_file=None, xml_lang=None, schema_location=False):
+                     name=None, version=None, new_root_path=None, pkcs12_file=None, xml_lang=None, schema_location=False,
+                     dpkg_include_package_arch=False):
     """
     Return SWID tags as utf8-encoded xml bytestrings for all available
     packages.
@@ -135,6 +136,7 @@ def create_swid_tags(environment, entity_name, regid, os_string=None, architectu
     :param full: Whether to include file payload. Default is False.
     :param matcher: A function that defines whether to return a tag or not. Default is a function that returns ``True`` for all tags.
     :param xml_lang: xml:lang attribute value. Default en-US.
+    :param dpkg_include_package_arch: Whether to include architecture in tagId and version.
 
     Returns:
         A generator object for all available SWID XML strings. The XML strings
@@ -156,6 +158,7 @@ def create_swid_tags(environment, entity_name, regid, os_string=None, architectu
         'new_root_path': new_root_path,
         'xml_lang': xml_lang,
         'schema_location': schema_location,
+        'dpkg_include_package_arch': dpkg_include_package_arch,
     }
 
     if os_string is None:
@@ -165,7 +168,7 @@ def create_swid_tags(environment, entity_name, regid, os_string=None, architectu
         ctx['architecture'] = ctx['environment'].get_architecture()
 
     if file_path is not None:
-        pi = environment.get_packageinfo_from_packagefile(file_path)
+        pi = environment.get_packageinfo_from_packagefile(file_path, ctx)
 
         ctx['package_info'] = pi
 
@@ -215,7 +218,7 @@ def create_swid_tags(environment, entity_name, regid, os_string=None, architectu
         yield XML_DECLARATION.encode('utf-8') + swidtag
 
     else:
-        pkg_info = environment.get_package_list()
+        pkg_info = environment.get_package_list(ctx)
 
         for pi in pkg_info:
 

--- a/swid_generator/main.py
+++ b/swid_generator/main.py
@@ -74,6 +74,7 @@ def main():
             'regid': options.regid,
             'os_string': options.os_string,
             'architecture': options.architecture,
+            'dpkg_include_package_arch': options.dpkg_include_package_arch,
             'full': options.full,
             'matcher': options.matcher,
             'hash_algorithms': options.hash_algorithms,

--- a/tests/dumps/console_output/dpkg_package_arch_query.txt
+++ b/tests/dumps/console_output/dpkg_package_arch_query.txt
@@ -1,15 +1,15 @@
 adduser
-3.113+nmu3ubuntu4
+3.113+nmu3ubuntu4.all
 install ok installed
  /etc/deluser.conf 773fb95e98a27947de4a95abb3d3f2a2	apt
-1.2.19
+1.2.19.amd64
 install ok installed
  /etc/apt/apt.conf.d/01-vendor-ubuntu 5232396660502461fc834c0a1229dbe4
  /etc/apt/apt.conf.d/01autoremove 0b1391c01d75f95fa4ea5ac01219b515
  /etc/cron.daily/apt-compat bc4a71cbcaeed4179f25d798257fa980
  /etc/kernel/postinst.d/apt-auto-removal 8ad76ae4492b54f0dcbf18c79429dfab
  /etc/logrotate.d/apt 179f2ed4f85cbaca12fa3d69c2a4a1c3	base-files
-9.4ubuntu4.4
+9.4ubuntu4.4.amd64
  install ok installed
   /etc/debian_version e90148aa8aae3eb74ca11dc306b03dcd
  /etc/dpkg/origins/debian 731423fa8ba067262f8ef37882d1e742

--- a/tests/dumps/console_output/dpkg_package_query.txt
+++ b/tests/dumps/console_output/dpkg_package_query.txt
@@ -1,15 +1,15 @@
 adduser
-3.113+nmu3ubuntu4
+3.113+nmu3ubuntu4.all
 install ok installed
  /etc/deluser.conf 773fb95e98a27947de4a95abb3d3f2a2	apt
-1.2.19
+1.2.19.amd64
 install ok installed
  /etc/apt/apt.conf.d/01-vendor-ubuntu 5232396660502461fc834c0a1229dbe4
  /etc/apt/apt.conf.d/01autoremove 0b1391c01d75f95fa4ea5ac01219b515
  /etc/cron.daily/apt-compat bc4a71cbcaeed4179f25d798257fa980
  /etc/kernel/postinst.d/apt-auto-removal 8ad76ae4492b54f0dcbf18c79429dfab
  /etc/logrotate.d/apt 179f2ed4f85cbaca12fa3d69c2a4a1c3	base-files
-9.4ubuntu4.4
+9.4ubuntu4.4.amd64
  install ok installed
   /etc/debian_version e90148aa8aae3eb74ca11dc306b03dcd
  /etc/dpkg/origins/debian 731423fa8ba067262f8ef37882d1e742

--- a/tests/dumps/console_output/rpm_package_query.txt
+++ b/tests/dumps/console_output/rpm_package_query.txt
@@ -1,1 +1,1 @@
-	perl-Git 2.9.3-3.fc25	fedora-repos 25-3	perl-IO-Socket-SSL 2.038-1.fc25	setup 2.10.4-1.fc25
+	perl-Git 2.9.3-3.fc25.noarch	fedora-repos 25-3.noarch	perl-IO-Socket-SSL 2.038-1.fc25.noarch	setup 2.10.4-1.fc25.noarch

--- a/tests/fixtures/command_manager_mock.py
+++ b/tests/fixtures/command_manager_mock.py
@@ -23,7 +23,7 @@ class CommandManagerMock(object):
 
     @staticmethod
     def run_command_check_output(command_argumentlist, stdin=None, working_directory=os.getcwd()):
-        if command_argumentlist == ['rpm', '-qa', '--queryformat', '\t%{name} %{version}-%{release}']:
+        if command_argumentlist == ['rpm', '-qa', '--queryformat', '\t%{name} %{version}-%{release}.%{arch}']:
             return mock_data.rpm_query_package_list_output
         if command_argumentlist == ['rpm', '-ql', 'docker']:
             return mock_data.rpm_query_file_list
@@ -31,13 +31,13 @@ class CommandManagerMock(object):
             return mock_data.rpm_query_conffile_list
         if command_argumentlist == ['rpm', "--query", "--package", "--queryformat", "%{name}", "/tmp/docker.pkg"]:
             return "docker"
-        if command_argumentlist == ['rpm', "--query", "--package", "--queryformat", "%{version}-%{release}", "/tmp/docker.pkg"]:
+        if command_argumentlist == ['rpm', "--query", "--package", "--queryformat", "%{version}-%{release}.%{arch}", "/tmp/docker.pkg"]:
             return "1.0-5"
         if command_argumentlist == ['rpm', "--query", "--package", "/tmp/docker.pkg", "-l"]:
             return mock_data.rpm_query_file_list
         if command_argumentlist == ['rpm', "--query", "--package", "/tmp/docker.pkg", "-c"]:
             return mock_data.rpm_query_conffile_list
-        if command_argumentlist == ['dpkg-query', '-W', '-f=${Package}\\n${Version}\\n${Status}\\n${conffiles}\\t']:
+        if command_argumentlist == ['dpkg-query', '-W', '-f=${Package}\\n${Version}.${Architecture}\\n${Status}\\n${conffiles}\\t']:
             return mock_data.dpkg_query_package_list_output
         if command_argumentlist == ['dpkg-query', '-L', "docker"]:
             return mock_data.dpkg_query_file_list
@@ -47,6 +47,8 @@ class CommandManagerMock(object):
             return "docker"
         if command_argumentlist == ['dpkg', '-f', '/tmp/docker.pkg', 'Version']:
             return "1.0-5"
+        if command_argumentlist == ['dpkg', '-f', '/tmp/docker.pkg', 'Architecture']:
+            return "amd64"
         if command_argumentlist == ['dpkg', '-c', '/tmp/docker.pkg']:
             return mock_data.dpkg_query_file_list_package
         if command_argumentlist == ['pacman', '-Q', '--color', 'never']:

--- a/tests/fixtures/command_manager_mock.py
+++ b/tests/fixtures/command_manager_mock.py
@@ -37,8 +37,10 @@ class CommandManagerMock(object):
             return mock_data.rpm_query_file_list
         if command_argumentlist == ['rpm', "--query", "--package", "/tmp/docker.pkg", "-c"]:
             return mock_data.rpm_query_conffile_list
-        if command_argumentlist == ['dpkg-query', '-W', '-f=${Package}\\n${Version}.${Architecture}\\n${Status}\\n${conffiles}\\t']:
+        if command_argumentlist == ['dpkg-query', '-W', '-f=${Package}\\n${Version}\\n${Status}\\n${conffiles}\\t']:
             return mock_data.dpkg_query_package_list_output
+        if command_argumentlist == ['dpkg-query', '-W', '-f=${Package}\\n${Version}.${Architecture}\\n${Status}\\n${conffiles}\\t']:
+            return mock_data.dpkg_query_package_arch_list_output
         if command_argumentlist == ['dpkg-query', '-L', "docker"]:
             return mock_data.dpkg_query_file_list
         if command_argumentlist == ['dpkg-query', '-W', '-f=${conffiles}\\n', "docker"]:

--- a/tests/fixtures/mock_data.py
+++ b/tests/fixtures/mock_data.py
@@ -14,6 +14,7 @@ rpm_query_conffile_list = _read_file("tests/dumps/console_output/rpm_conffile_li
 
 # DpkgEnvironment
 dpkg_query_package_list_output = _read_file("tests/dumps/console_output/dpkg_package_query.txt")
+dpkg_query_package_arch_list_output = _read_file("tests/dumps/console_output/dpkg_package_arch_query.txt")
 dpkg_query_file_list = _read_file("tests/dumps/console_output/dpkg_file_list.txt")
 dpkg_query_conffile_list = _read_file("tests/dumps/console_output/dpkg_conffile_list.txt")
 dpkg_query_file_list_package = _read_file("tests/dumps/console_output/dpkg_file_list_package.txt")

--- a/tests/test_dpkg_evironment.py
+++ b/tests/test_dpkg_evironment.py
@@ -43,9 +43,9 @@ class DpkgEnvironmentTests(unittest.TestCase):
 
         expected_package_list = list()
 
-        expected_package_list.append(PackageInfo(package="adduser", version="3.113+nmu3ubuntu4"))
-        expected_package_list.append(PackageInfo(package="apt", version="1.2.19"))
-        expected_package_list.append(PackageInfo(package="base-files", version="9.4ubuntu4.4"))
+        expected_package_list.append(PackageInfo(package="adduser", version="3.113+nmu3ubuntu4.all"))
+        expected_package_list.append(PackageInfo(package="apt", version="1.2.19.amd64"))
+        expected_package_list.append(PackageInfo(package="base-files", version="9.4ubuntu4.4.amd64"))
 
         for index, result_package in enumerate(result_list):
             print(result_package.package)
@@ -81,7 +81,7 @@ class DpkgEnvironmentTests(unittest.TestCase):
         print(result_package.package)
 
         assert result_package.package == 'docker'
-        assert result_package.version == '1.0-5'
+        assert result_package.version == '1.0-5.amd64'
 
     def test_get_files_from_packagefile(self):
         all_files = self.dpkg_environment.get_files_from_packagefile("/tmp/docker.pkg")

--- a/tests/test_dpkg_evironment.py
+++ b/tests/test_dpkg_evironment.py
@@ -43,6 +43,21 @@ class DpkgEnvironmentTests(unittest.TestCase):
 
         expected_package_list = list()
 
+        expected_package_list.append(PackageInfo(package="adduser", version="3.113+nmu3ubuntu4"))
+        expected_package_list.append(PackageInfo(package="apt", version="1.2.19"))
+        expected_package_list.append(PackageInfo(package="base-files", version="9.4ubuntu4.4"))
+
+        for index, result_package in enumerate(result_list):
+            print(result_package.package)
+            print(result_package.version)
+            assert result_package.package == expected_package_list[index].package
+            assert result_package.version == expected_package_list[index].version
+
+    def test_get_package_arch_list(self):
+        result_list = self.dpkg_environment.get_package_list({ "dpkg_include_package_arch": True })
+
+        expected_package_list = list()
+
         expected_package_list.append(PackageInfo(package="adduser", version="3.113+nmu3ubuntu4.all"))
         expected_package_list.append(PackageInfo(package="apt", version="1.2.19.amd64"))
         expected_package_list.append(PackageInfo(package="base-files", version="9.4ubuntu4.4.amd64"))
@@ -77,6 +92,14 @@ class DpkgEnvironmentTests(unittest.TestCase):
 
     def test_get_packageinfo_from_packagefile(self):
         result_package = self.dpkg_environment.get_packageinfo_from_packagefile("/tmp/docker.pkg")
+
+        print(result_package.package)
+
+        assert result_package.package == 'docker'
+        assert result_package.version == '1.0-5'
+
+    def test_get_packageinfo_arch_from_packagefile(self):
+        result_package = self.dpkg_environment.get_packageinfo_from_packagefile("/tmp/docker.pkg", { "dpkg_include_package_arch": True })
 
         print(result_package.package)
 

--- a/tests/test_rpm_evironment.py
+++ b/tests/test_rpm_evironment.py
@@ -44,10 +44,10 @@ class RpmEnvironmentTests(unittest.TestCase):
 
         expected_package_list = list()
 
-        expected_package_list.append(PackageInfo(package="perl-Git", version="2.9.3-3.fc25"))
-        expected_package_list.append(PackageInfo(package="fedora-repos", version="25-3"))
-        expected_package_list.append(PackageInfo(package="perl-IO-Socket-SSL", version="2.038-1.fc25"))
-        expected_package_list.append(PackageInfo(package="setup", version="2.10.4-1.fc25"))
+        expected_package_list.append(PackageInfo(package="perl-Git", version="2.9.3-3.fc25.noarch"))
+        expected_package_list.append(PackageInfo(package="fedora-repos", version="25-3.noarch"))
+        expected_package_list.append(PackageInfo(package="perl-IO-Socket-SSL", version="2.038-1.fc25.noarch"))
+        expected_package_list.append(PackageInfo(package="setup", version="2.10.4-1.fc25.noarch"))
 
         for index, result_package in enumerate(result_list):
             print(result_package.package)


### PR DESCRIPTION
This is necessary for multiarch packages, and also for uninstalled package files where the architecture of the OS doesn't imply architecture of the package.

This pull request is on top of https://github.com/strongswan/swidGenerator/pull/44.
